### PR TITLE
feat: gate Stop friction hook on zombuul command sentinel

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,48 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bump:
+    # Skip on version bump commits to avoid infinite loop
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          PLUGIN_JSON=".claude-plugin/plugin.json"
+          CURRENT=$(python3 -c "import json; d=open('$PLUGIN_JSON').read(); print(json.loads(d)['version'])")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          python3 -c "
+          import json
+          with open('$PLUGIN_JSON') as f:
+              d = json.load(f)
+          d['version'] = '$NEW_VERSION'
+          with open('$PLUGIN_JSON', 'w') as f:
+              json.dump(d, f, indent=2)
+              f.write('\n')
+          "
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+          git tag "v${{ steps.bump.outputs.new_version }}"
+          git push
+          git push --tags

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,11 +1,32 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rm -f /tmp/zombuul_session_active"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mark_session_active.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Before stopping, reflect on this session. Did you encounter any friction, errors, unexpected behavior, workarounds, or things that didn't go smoothly? This includes: commands that failed and needed retrying, confusing instructions in specs or commands, missing files or wrong paths, tools that didn't work as expected, configurations that needed manual fixing, or anything that slowed you down.\n\nIf there was NO friction (everything went smoothly), respond {\"decision\": \"allow\"} and do nothing else.\n\nIf there WAS friction, post each issue to Slack (if SLACK_BOT_TOKEN and SLACK_CHANNEL_ID are set) using this format:\n\nWrite a JSON file /tmp/slack_friction.json:\n{\"channel\": \"<SLACK_CHANNEL_ID>\", \"text\": \"<message>\", \"username\": \"friction-log\", \"icon_url\": \"https://dummyimage.com/48x48/ff6b6b/ff6b6b.png\"}\n\nThe message should be:\n:warning: **Friction report**\n> <one-line summary>\n> **Severity**: minor/moderate/major\n> **Details**: 1-3 sentences on what happened\n\nPost with: curl -s -X POST -H \"Authorization: Bearer $SLACK_BOT_TOKEN\" -H 'Content-type: application/json' -d @/tmp/slack_friction.json https://slack.com/api/chat.postMessage\n\nPost one message per distinct issue. Then respond {\"decision\": \"allow\"}."
+            "prompt": "[zombuul friction logger] First check whether /tmp/zombuul_session_active exists by running: test -f /tmp/zombuul_session_active\n\nIf it does NOT exist, respond exactly {\"decision\": \"allow\"} and stop immediately — no zombuul commands were used this session.\n\nIf it DOES exist: delete it with rm /tmp/zombuul_session_active, then reflect on zombuul-related friction in this session. Did you encounter errors, workarounds, or things that didn't go smoothly while using zombuul commands (launch-runpod, launch-research-pod, stop-runpod, check-slack, setup)? This includes: RunPod API failures, SSH issues, wrong paths or missing files, pod setup errors, Slack posting failures, or anything that slowed the research loop down.\n\nIf there was NO friction, respond {\"decision\": \"allow\"} and do nothing else.\n\nIf there WAS friction, post each issue to Slack (if SLACK_BOT_TOKEN and SLACK_CHANNEL_ID are set):\n\nWrite /tmp/slack_friction.json:\n{\"channel\": \"<SLACK_CHANNEL_ID>\", \"text\": \"<message>\", \"username\": \"friction-log\", \"icon_url\": \"https://dummyimage.com/48x48/ff6b6b/ff6b6b.png\"}\n\nMessage format:\n:warning: *Friction report* (zombuul)\n> <one-line summary>\n> *Severity*: minor/moderate/major\n> *Details*: 1-3 sentences\n\nPost with: curl -s -X POST -H \"Authorization: Bearer $SLACK_BOT_TOKEN\" -H 'Content-type: application/json' -d @/tmp/slack_friction.json https://slack.com/api/chat.postMessage\n\nPost one message per distinct issue. Then respond {\"decision\": \"allow\"}."
           }
         ]
       }

--- a/hooks/mark_session_active.sh
+++ b/hooks/mark_session_active.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Touches /tmp/zombuul_session_active when a zombuul skill/command is invoked.
+# Called from PreToolUse hook on the Skill tool.
+# Try both field names in case the SDK uses either.
+skill=$(echo "$CLAUDE_TOOL_INPUT" | jq -r '(.tool_input.skill // .tool_input.skill_name) // empty')
+case "$skill" in
+  zombuul:*)
+    touch /tmp/zombuul_session_active
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `hooks/mark_session_active.sh`: touches `/tmp/zombuul_session_active` when a `zombuul:*` skill is invoked (via `PreToolUse` on the `Skill` tool, using `CLAUDE_TOOL_INPUT` + `jq`)
- `SessionStart` hook clears the sentinel at the start of each new session
- `Stop` hook prompt now checks for the sentinel first — if absent, responds `{"decision": "allow"}` immediately without any reflection; if present, runs the friction check and cleans up

## Why

The Stop hook was firing after every session regardless of whether zombuul was used, which was noisy and confusing.

## Unknowns

- The exact field name in `CLAUDE_TOOL_INPUT` for the skill name (`tool_input.skill` vs `tool_input.skill_name`) — the script tries both; we'll confirm from logs after first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)