### PR TITLE
Fix: load project .env when collecting pod environment tokens

### DIFF
--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -119,6 +119,8 @@ def ssh_run(ip: str, port: int, command: str | list[str], **kwargs) -> subproces
 # --- Pod info ---
 
 def get_pod_env() -> dict[str, str]:
+    """Collect tokens for the pod from environment and project .env file."""
+    load_dotenv()  # load project .env into os.environ (no-op for already-set vars)
     return {k: v for k in ("HF_TOKEN", "GH_TOKEN", "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID") if (v := os.environ.get(k))}
 
 


### PR DESCRIPTION
## Summary
- `get_pod_env()` only read from `os.environ`, missing tokens like `GH_TOKEN` that live in the project `.env` but aren't exported to the shell
- This caused pods to launch without GitHub credentials, so the research loop couldn't push commits
- Fix: call `load_dotenv()` before reading tokens, which loads the project `.env` into `os.environ` (no-op for vars already set)

## Test plan
- [ ] Launch a research pod from a project with `GH_TOKEN` in `.env` (not exported) and verify the pod can `git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)