### PR TITLE
Reduce positive-result bias in research agent prompts

### DIFF
--- a/commands/launch-research-loop.md
+++ b/commands/launch-research-loop.md
@@ -9,7 +9,7 @@ If `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` are set in the environment, you can 
 Post to Slack at these moments:
 - **Missing data** — if the spec references files that don't exist on this machine (activations, probe weights, etc.), post immediately listing what's missing and what steps are blocked. Then proceed with whatever steps you can.
 - **Blocking issue** you cannot resolve after multiple attempts
-- **Strong or surprising result** (e.g. significant accuracy jump, unexpected pattern)
+- **Noteworthy result** — positive, negative, or null — that updates our understanding
 - **Experiment complete** (one-line summary of outcome)
 - **Asking for help** — if you're stuck and want human or supervisor input, describe what you need
 
@@ -55,7 +55,8 @@ If `IS_SANDBOX=1` is set, you are running on a remote GPU pod. This means:
 - **Do not give up easily.** If something fails, debug it, try a different approach, read more code, re-examine assumptions. Iterate aggressively.
 - **Do not cut corners.** If the problem requires running experiments, run them. If it requires reading papers or code, read them.
 - **Pay attention to the instructions.** They should define the research space. They should also provide fallback options and different things to try. Do not do something that the instructions tell you not to.
-- **Think about controls.** For each key result, think about what controls or sanity checks would strengthen the claim. Run them without being asked.
+- **Think about controls.** For each key result, think about what controls or sanity checks would test the claim. Run them without being asked.
+- **Report what you find, not what you hoped to find.** A null or negative result is just as informative as a positive one — often more so. Do not spin results, cherry-pick coefficients, or frame ambiguous evidence as support for the hypothesis. If the data doesn't show an effect, say so plainly.
 - **Pilot before scaling.** When running experiments at scale, always run a small pilot first to validate the pipeline, check for obvious issues, and get rough effect sizes. Use pilot results to decide what to iterate on before committing to full runs.
 - **Do not provision infrastructure.** Never create pods, VMs, or cloud resources. You run experiments on the machine you're on.
 - **Results go in the experiment report only.** Do not write results anywhere else. The user will decide where to log them.

--- a/commands/launch-research-ralph.md
+++ b/commands/launch-research-ralph.md
@@ -8,7 +8,7 @@ The argument $ARGUMENTS points to a top-level experiment directory: `experiments
 2. **Find all completed experiments.** List all `*_report.md` files in `experiments/{name}/` and its subdirectories. Order them chronologically (by file modification time or by the sequence implied by parent→child relationships).
 3. **Synthesize older reports.** If there are 2+ reports, launch a subagent (Task tool, subagent_type="general-purpose"): "Read these reports in order: {list all but the latest}. Write a synthesis to `experiments/{name}/synthesis.md` with: (a) what's been established, (b) what failed and why, (c) open questions. Be concise — this is background context, not the focus." Then read `synthesis.md`.
 4. **Read the latest report in full.** This is the most important input — read it directly, not via summary.
-5. **Check if done.** If the overall goal is convincingly addressed — positive results or enough negative evidence to close the question — output <promise>RESEARCH_COMPLETE</promise> and stop.
+5. **Check if done.** If the overall goal is convincingly addressed — whether by positive results, null results, or negative evidence that closes the question — output <promise>RESEARCH_COMPLETE</promise> and stop.
 6. **Design the next experiment.** Write a focused spec at `experiments/{name}/{follow_up_name}/{follow_up_name}_spec.md`.
 7. **Run the experiment.** Invoke `/launch-research-loop experiments/{name}/{follow_up_name}/{follow_up_name}_spec.md`.
 8. **Push synthesis.** If you wrote or updated `synthesis.md`, commit and push it.

--- a/commands/review-experiment-report.md
+++ b/commands/review-experiment-report.md
@@ -21,7 +21,7 @@ Interpretation/discussion sections should be a bulleted list of one-liners, not 
 - Bad: "We tried alpha values from 0.1 to 10000 using 5-fold CV. The best alpha was 2154. This gave R²=0.86."
 - Good: "Ridge probes achieve R²=0.86 (best alpha=2154 via 5-fold CV)."
 - Bad interpretation: A paragraph discussing what a technique does, why a gap is small, and what it implies.
-- Good interpretation: "**Augmentation closes the train-test gap** (82% → 79%), confirming the model isn't overfitting to source-specific artifacts."
+- Good interpretation: "**Augmentation closes the train-test gap** (82% → 79%), suggesting the model isn't overfitting to source-specific artifacts."
 
 ### 2. Naming
 


### PR DESCRIPTION
## Summary
- Symmetric completion criteria in ralph (positive/null/negative all valid)
- Neutral Slack posting trigger ("noteworthy" not "strong or surprising")
- "Test the claim" not "strengthen the claim" for controls
- Add explicit rule: report what you find, not what you hoped to find
- "Suggesting" not "confirming" in report review example

🤖 Generated with [Claude Code](https://claude.com/claude-code)