### PR TITLE
Migrate all commands to skills format

### DIFF
--- a/skills/check-slack/SKILL.md
+++ b/skills/check-slack/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: check-slack
 description: Check the zombuul Slack channel for agent messages.
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
 

--- a/skills/launch-research-loop/SKILL.md
+++ b/skills/launch-research-loop/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: launch-research-loop
+description: >
+  Run an autonomous research loop for a single experiment.
+  Argument $ARGUMENTS — path to experiment spec.
+user-invocable: true
+---
+
 Solve this research problem autonomously: $ARGUMENTS
 
 ## Slack

--- a/skills/launch-research-pod/SKILL.md
+++ b/skills/launch-research-pod/SKILL.md
@@ -1,5 +1,9 @@
 ---
-description: Spin up a RunPod GPU pod and launch a research loop on it. Argument $ARGUMENTS — path to experiment spec (e.g. experiments/content_orthogonal_gemma2base.md).
+name: launch-research-pod
+description: >
+  Spin up a RunPod GPU pod and launch a research loop on it.
+  Argument $ARGUMENTS — path to experiment spec (e.g. experiments/content_orthogonal_gemma2base.md).
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion, Write
 ---
 

--- a/skills/launch-research-ralph/SKILL.md
+++ b/skills/launch-research-ralph/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: launch-research-ralph
+description: >
+  Run a multi-experiment research program that iterates until the research goal is met.
+  Argument $ARGUMENTS — path to top-level experiment directory.
+user-invocable: true
+---
+
 You are running a research program — a sequence of experiments that build on each other. This prompt will be re-invoked after each experiment completes.
 
 The argument $ARGUMENTS points to a top-level experiment directory: `experiments/{name}/`.

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name.
+name: launch-runpod
+description: >
+  Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name.
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion, Read, Edit
 ---
 

--- a/skills/pause-runpod/SKILL.md
+++ b/skills/pause-runpod/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: pause-runpod
 description: Pause a RunPod pod (stop GPU billing, keep disk).
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
 

--- a/skills/resume-runpod/SKILL.md
+++ b/skills/resume-runpod/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: resume-runpod
 description: Resume a paused RunPod pod.
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
 

--- a/skills/review-experiment-report/SKILL.md
+++ b/skills/review-experiment-report/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: review-experiment-report
+description: >
+  Review and rewrite a research report for clarity.
+  Argument $ARGUMENTS — path to the report markdown file.
+user-invocable: true
+---
+
 Review and rewrite this research report for clarity: $ARGUMENTS
 
 You are reviewing a research report as a **naive reader** — someone who understands ML but has not seen the code, the running log, or any implementation details. Your only inputs are the report itself and the experiment spec.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -3,7 +3,7 @@ name: setup
 description: >
   Interactive onboarding for zombuul. Walks through prerequisites, API keys,
   .env creation, and verifies everything works. Run this after installing the plugin.
-user_invocable: true
+user-invocable: true
 ---
 
 You are running the zombuul setup wizard. The philosophy is **detect first, ask only when something is missing**. Run all checks silently, then present a summary of what's already configured and what needs action.

--- a/skills/stop-runpod/SKILL.md
+++ b/skills/stop-runpod/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: stop-runpod
 description: List and terminate RunPod pods.
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary
- Move all 9 commands from `commands/` to `skills/<name>/SKILL.md` with proper skill frontmatter (`name`, `description`, `user-invocable`, `allowed-tools`)
- Add frontmatter to the 3 commands that had none (`launch-research-loop`, `launch-research-ralph`, `review-experiment-report`)
- Fix `user_invocable` → `user-invocable` typo in existing setup skill

## Test plan
- [ ] Reinstall plugin: `claude plugin add --local /Users/oscargilg/Dev/zombuul`
- [ ] Restart Claude Code
- [ ] Verify all 10 skills appear when typing `/zombuul:`
- [ ] Spot-check one skill invocation (e.g. `/zombuul:stop-runpod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)