### PR TITLE
Fix version bump and skill slash commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,19 @@
     {
       "name": "zombuul",
       "source": "./",
-      "description": "Autonomous research loops on GPU pods with Claude Code"
+      "description": "Autonomous research loops on GPU pods with Claude Code",
+      "commands": [
+        "./skills/check-slack/SKILL.md",
+        "./skills/launch-research-loop/SKILL.md",
+        "./skills/launch-research-pod/SKILL.md",
+        "./skills/launch-research-ralph/SKILL.md",
+        "./skills/launch-runpod/SKILL.md",
+        "./skills/pause-runpod/SKILL.md",
+        "./skills/resume-runpod/SKILL.md",
+        "./skills/review-experiment-report/SKILL.md",
+        "./skills/setup/SKILL.md",
+        "./skills/stop-runpod/SKILL.md"
+      ]
     }
   ]
 }

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           fetch-depth: 0
 
       - name: Bump patch version


### PR DESCRIPTION
## Summary
- Use `PAT` secret instead of `GITHUB_TOKEN` in version-bump workflow — the bot can't push to main with `enforce_admins` enabled
- Add skill SKILL.md paths to `commands` array in marketplace.json — workaround for [claude-code#17509](https://github.com/anthropics/claude-code/issues/17509) where skills with `user-invocable: true` don't appear in the slash command menu

## Test plan
- [ ] Merge and verify version bump action succeeds (requires `PAT` repo secret with `repo` scope)
- [ ] Reinstall plugin and verify `/check-slack`, `/stop-runpod` etc. are invocable

🤖 Generated with [Claude Code](https://claude.com/claude-code)