### PR TITLE
Revert version-bump to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Bump patch version


### PR DESCRIPTION
## Summary
- Revert version-bump workflow back to `GITHUB_TOKEN` — `enforce_admins` has been disabled on main so the default token can push version bumps

## Test plan
- [ ] Merge this PR and verify the version bump action succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)