### PR TITLE
Use PAT for version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           fetch-depth: 0
 
       - name: Bump patch version


### PR DESCRIPTION
## Summary
- Revert to `PAT` secret — `GITHUB_TOKEN` cannot push to main even with `enforce_admins` off because the PR requirement blocks all non-bypass pushes
- Re-enabled `enforce_admins` on main

## Required setup
Add a `PAT` repository secret (Settings > Secrets > Actions) with a personal access token that has `repo` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)