### PR TITLE
Fix duplicate skill registration in slash menu

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,16 +7,16 @@
       "source": "./",
       "description": "Autonomous research loops on GPU pods with Claude Code",
       "skills": [
-        "./skills/check-slack",
-        "./skills/launch-research-loop",
-        "./skills/launch-research-pod",
-        "./skills/launch-research-ralph",
-        "./skills/launch-runpod",
-        "./skills/pause-runpod",
-        "./skills/resume-runpod",
-        "./skills/review-experiment-report",
-        "./skills/setup",
-        "./skills/stop-runpod"
+        "./skill-defs/check-slack",
+        "./skill-defs/launch-research-loop",
+        "./skill-defs/launch-research-pod",
+        "./skill-defs/launch-research-ralph",
+        "./skill-defs/launch-runpod",
+        "./skill-defs/pause-runpod",
+        "./skill-defs/resume-runpod",
+        "./skill-defs/review-experiment-report",
+        "./skill-defs/setup",
+        "./skill-defs/stop-runpod"
       ]
     }
   ]

--- a/skill-defs/check-slack/SKILL.md
+++ b/skill-defs/check-slack/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: check-slack
+name: zombuul:check-slack
 description: Check the zombuul Slack channel for agent messages.
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion

--- a/skill-defs/launch-research-loop/SKILL.md
+++ b/skill-defs/launch-research-loop/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launch-research-loop
+name: zombuul:launch-research-loop
 description: >
   Run an autonomous research loop for a single experiment.
   Argument $ARGUMENTS — path to experiment spec.

--- a/skill-defs/launch-research-pod/SKILL.md
+++ b/skill-defs/launch-research-pod/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launch-research-pod
+name: zombuul:launch-research-pod
 description: >
   Spin up a RunPod GPU pod and launch a research loop on it.
   Argument $ARGUMENTS — path to experiment spec (e.g. experiments/content_orthogonal_gemma2base.md).

--- a/skill-defs/launch-research-ralph/SKILL.md
+++ b/skill-defs/launch-research-ralph/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launch-research-ralph
+name: zombuul:launch-research-ralph
 description: >
   Run a multi-experiment research program that iterates until the research goal is met.
   Argument $ARGUMENTS — path to top-level experiment directory.

--- a/skill-defs/launch-runpod/SKILL.md
+++ b/skill-defs/launch-runpod/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: launch-runpod
+name: zombuul:launch-runpod
 description: >
   Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name.
 user-invocable: true

--- a/skill-defs/pause-runpod/SKILL.md
+++ b/skill-defs/pause-runpod/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pause-runpod
+name: zombuul:pause-runpod
 description: Pause a RunPod pod (stop GPU billing, keep disk).
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion

--- a/skill-defs/resume-runpod/SKILL.md
+++ b/skill-defs/resume-runpod/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume-runpod
+name: zombuul:resume-runpod
 description: Resume a paused RunPod pod.
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion

--- a/skill-defs/review-experiment-report/SKILL.md
+++ b/skill-defs/review-experiment-report/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: review-experiment-report
+name: zombuul:review-experiment-report
 description: >
   Review and rewrite a research report for clarity.
   Argument $ARGUMENTS — path to the report markdown file.

--- a/skill-defs/setup/SKILL.md
+++ b/skill-defs/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup
+name: zombuul:setup
 description: >
   Interactive onboarding for zombuul. Walks through prerequisites, API keys,
   .env creation, and verifies everything works. Run this after installing the plugin.

--- a/skill-defs/stop-runpod/SKILL.md
+++ b/skill-defs/stop-runpod/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: stop-runpod
+name: zombuul:stop-runpod
 description: List and terminate RunPod pods.
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion


### PR DESCRIPTION
## Summary
- Rename `skills/` to `skill-defs/` to prevent auto-discovery from registering skills alongside the explicit `marketplace.json` list
- Add `zombuul:` prefix to all skill `name:` frontmatter fields
- Update `marketplace.json` paths to match new directory

## Test plan
- [ ] Verify skills appear once (not duplicated) in the slash menu
- [ ] Verify skills show as `zombuul:check-slack` etc. (with prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)