### PR TITLE
Replace tmux with nohup, fix SSH exit codes

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -44,7 +44,7 @@ fi
 # --- system tools ---
 
 retry "apt-get update" 3 10 apt-get update
-retry "install tmux+jq" 3 10 apt-get install -y tmux jq
+retry "install jq+rsync" 3 10 apt-get install -y jq rsync
 
 # gh CLI (non-critical — used for PR operations but not essential)
 install_gh() {

--- a/skill-defs/launch-research-pod/SKILL.md
+++ b/skill-defs/launch-research-pod/SKILL.md
@@ -40,12 +40,12 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
 9. **Copy .env**: If a `.env` file exists in the current working directory:
    `scp -P <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no .env root@<IP>:/workspace/repo/.env`
 
-10. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it with `nohup`. Use the **namespaced** command the user chose in step 3 (`/zombuul:launch-research-loop` or `/zombuul:launch-research-ralph`) — the non-namespaced versions don't resolve on the pod. Pass the full path to the spec file (not `@` syntax):
+10. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it with `nohup`. Use the command the user chose in step 3 (`/launch-research-loop` or `/launch-research-ralph`). Pass the full path to the spec file (not `@` syntax):
    - Use the **Write tool** to create `/tmp/launch_research.sh` locally with this content (substitute the chosen command and spec path):
      ```
      source ~/.bash_profile
      cd /workspace/repo
-     IS_SANDBOX=1 claude --dangerously-skip-permissions --effort high -p '/zombuul:<chosen_command> <full_spec_path>'
+     IS_SANDBOX=1 claude --dangerously-skip-permissions --effort high -p '/<chosen_command> <full_spec_path>'
      runpodctl stop pod $RUNPOD_POD_ID
      ```
    - SCP it to the pod: `scp -P <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no /tmp/launch_research.sh root@<IP>:/tmp/launch_research.sh`

--- a/skill-defs/launch-research-pod/SKILL.md
+++ b/skill-defs/launch-research-pod/SKILL.md
@@ -23,14 +23,16 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
    - **GPU**: Which GPU they want. Offer 3-4 common options from the list plus an "Other" escape hatch.
    - **Mode**: Which research mode to use. Options: (a) "Single experiment (/launch-research-loop)" — runs one experiment and stops; (b) "Ralph mode (/launch-research-ralph)" — runs experiments in a loop, each building on the last, until the research goal is met.
 
-4. **Sync gitignored data**: Read the experiment spec and check for references to data files (activations, embeddings, results, etc.) that are likely gitignored. Look for those files locally (follow symlinks). If any exist, ask the user which ones to SCP to the pod using AskUserQuestion — list the files with their sizes as options (multiSelect). SCP the selected files after setup completes (step 5), creating target directories on the pod first with `ssh ... "mkdir -p /workspace/repo/<dir>"`.
+4. **Sync gitignored data**: Read the experiment spec and check for references to data files (activations, embeddings, results, etc.) that are likely gitignored. Look for those files locally (follow symlinks). If any exist, ask the user which ones to SCP to the pod using AskUserQuestion — list the files with their sizes as options (multiSelect). SCP the selected files after setup completes (step 5), creating target directories on the pod first with `ssh ... bash -c 'mkdir -p /workspace/repo/<dir>'`.
 
 5. **Create the pod**: Read the experiment spec and pick a short, descriptive pod name (2-3 words, kebab-case, e.g. `probe-generalization` or `steering-math`). Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name "<pod_name>" --gpu "<gpu_type_id>"` **in the background** (docker image, volume, and disk size come from config — `~/.claude/zombuul.yaml` or defaults). Parse the SSH IP and port from the output (line like `SSH: ssh root@<IP> -p <PORT> ...`).
 
-6. **Wait for setup to complete**: Poll every 15 seconds by running `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no grep -c 'Setup complete' /var/log/pod_setup.log`. Once it returns "1", setup is done. Show the last line of the log each poll for progress. Timeout after 15 minutes. If setup fails, **do not manually run individual steps** — just re-run `pod_setup.sh` on the pod: `ssh ... "nohup bash /pod_setup.sh <repo_url> <branch> <python_version> > /var/log/pod_setup.log 2>&1 &"`. The script is idempotent (skips clone if repo exists).
+6. **Wait for setup to complete**: Poll every 15 seconds by running `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no bash -c 'grep -c "Setup complete" /var/log/pod_setup.log'`. Once it returns "1", setup is done. Show the last line of the log each poll for progress. Timeout after 15 minutes. If setup fails, **do not manually run individual steps** — just re-run `pod_setup.sh` on the pod: `ssh ... "nohup bash /pod_setup.sh <repo_url> <branch> <python_version> > /var/log/pod_setup.log 2>&1 &"`. The script is idempotent (skips clone if repo exists).
+
+   **IMPORTANT — SSH exit codes**: RunPod pods often have terminal escape codes in their shell profile that cause SSH commands to return exit code 1 even when the command succeeded. Always wrap remote commands with `bash -c '...'` to get a clean exit code. For example: `ssh ... bash -c 'mkdir -p /workspace/repo/foo'` instead of `ssh ... "mkdir -p /workspace/repo/foo"`.
 
 7. **Sync the experiment spec (REQUIRED)**: The spec file is often not committed/pushed. You MUST SCP it to the pod — never assume it exists from the git clone:
-   - Create the parent directory: `ssh ... "mkdir -p /workspace/repo/<spec_parent_dir>"`
+   - Create the parent directory: `ssh ... bash -c 'mkdir -p /workspace/repo/<spec_parent_dir>'`
    - Copy the spec: `scp -P <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no <local_spec_path> root@<IP>:/workspace/repo/<spec_path>`
 
 8. **Sync data**: SCP the files the user selected in step 3. Create target directories first, then copy. This can be done in parallel with .env copy.
@@ -38,7 +40,7 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
 9. **Copy .env**: If a `.env` file exists in the current working directory:
    `scp -P <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no .env root@<IP>:/workspace/repo/.env`
 
-10. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it in tmux. Use the **namespaced** command the user chose in step 3 (`/zombuul:launch-research-loop` or `/zombuul:launch-research-ralph`) — the non-namespaced versions don't resolve on the pod. Pass the full path to the spec file (not `@` syntax):
+10. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it with `nohup`. Use the **namespaced** command the user chose in step 3 (`/zombuul:launch-research-loop` or `/zombuul:launch-research-ralph`) — the non-namespaced versions don't resolve on the pod. Pass the full path to the spec file (not `@` syntax):
    - Use the **Write tool** to create `/tmp/launch_research.sh` locally with this content (substitute the chosen command and spec path):
      ```
      source ~/.bash_profile
@@ -47,15 +49,14 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
      runpodctl stop pod $RUNPOD_POD_ID
      ```
    - SCP it to the pod: `scp -P <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no /tmp/launch_research.sh root@<IP>:/tmp/launch_research.sh`
-   - Launch it in tmux: `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no "tmux new-session -d -s research 'bash /tmp/launch_research.sh'"`
-   - If the tmux launch fails, debug and retry with adjusted commands. The goal is a detached tmux session named `research`.
+   - Launch with nohup: `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no bash -c 'nohup bash /tmp/launch_research.sh > /workspace/research.log 2>&1 &'`
 
-11. **Verify**: Check that the tmux session is running: `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no "tmux list-sessions"`
+11. **Verify**: Check that the claude process is running: `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no bash -c 'ps aux | grep claude | grep -v grep'`
 
 12. **Report to user**:
-   - The research loop is running in tmux session `research` on the pod.
+   - The research loop is running on the pod.
    - SSH command: `ssh root@<IP> -p <PORT> -i ~/.ssh/id_ed25519`
-   - To watch progress: `tmux attach -t research`
+   - To watch progress: `tail -f /workspace/research.log`
    - The pod will auto-terminate after the research loop finishes. Run `/stop-runpod` to terminate early if needed.
 
 13. **Friction check**: Before finishing, reflect on whether anything went wrong or was harder than expected during this command (SSH failures, RunPod API issues, wrong paths, pod setup errors, confusing instructions, etc.). If there was friction and `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` are set, post a short friction report to Slack for each issue:


### PR DESCRIPTION
## Summary
- Replace tmux with `nohup` + log file for launching research loops — `tmux capture-pane` doesn't work with Claude Code's TUI, so progress was uncheckable. Now use `tail -f /workspace/research.log`.
- Wrap all SSH remote commands with `bash -c '...'` to avoid false exit code 1 from terminal escape codes in RunPod shell profiles.

## Test plan
- [ ] Run `/launch-research-pod` and verify SSH commands return exit code 0
- [ ] Verify `tail -f /workspace/research.log` shows Claude Code output
- [ ] Verify process check via `ps aux | grep claude` works with `bash -c` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)