### PR TITLE
Fix SSH patterns for RunPod pods

### DIFF
--- a/skill-defs/launch-runpod/SKILL.md
+++ b/skill-defs/launch-runpod/SKILL.md
@@ -47,5 +47,6 @@ Spin up a RunPod GPU pod interactively.
    - SSH command: `ssh runpod-<name>`
    - The setup script is running in the background on the pod (clones repo, installs deps). Check `/var/log/pod_setup.log` on the pod for progress.
    - Once setup is done, run `source ~/.bash_profile && cd /workspace/repo && IS_SANDBOX=1 claude --dangerously-skip-permissions --effort high`.
-   - If setup fails, don't debug individual steps — just re-run `pod_setup.sh`: `ssh runpod-<name> "nohup bash /pod_setup.sh <repo_url> <branch> > /var/log/pod_setup.log 2>&1 &"`. It's idempotent (skips clone if repo exists).
+   - If setup fails, don't debug individual steps — just re-run `pod_setup.sh`: `ssh runpod-<name> bash -c 'nohup bash /pod_setup.sh <repo_url> <branch> </dev/null > /var/log/pod_setup.log 2>&1 & disown; echo LAUNCHED'`. It's idempotent (skips clone if repo exists).
+   - **SSH patterns**: RunPod pods return exit code 1 on every SSH command due to terminal escape codes in `.bashrc`. Always wrap commands with `bash -c '...; echo DONE'` and check output instead of exit code. For background processes: `ssh runpod-<name> bash -c 'nohup <cmd> </dev/null > /log 2>&1 & disown; echo LAUNCHED'`.
    - They can run `/zombuul:stop-runpod` to terminate the pod when done.


### PR DESCRIPTION
## Summary
- Fix `runpod_ctl.py` setup launch: write a launcher script to the pod instead of running `nohup` inline via SSH (inline `nohup` gets mangled by RunPod's `.bashrc` escape codes → "nohup: missing operand")
- Use full `nohup ... </dev/null > log 2>&1 & disown` pattern for background processes that must survive SSH disconnect
- Update skill instructions: exit code 1 is always expected from RunPod SSH — check output sentinels instead

## Test plan
- [ ] Launch a pod with `/zombuul:launch-research-pod` and verify setup starts without "nohup: missing operand"
- [ ] Verify background processes (pod_setup.sh, research loop) survive SSH disconnect
- [ ] Verify polling commands work despite exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)