### PR TITLE
Favor results over interpretive prose in reports

### DIFF
--- a/skill-defs/launch-research-loop/SKILL.md
+++ b/skill-defs/launch-research-loop/SKILL.md
@@ -90,7 +90,7 @@ All scripts you write during this loop go here — experiment runners, analysis,
 
 ## Report style guide
 
-Scannable — someone should grasp the full arc in 30 seconds. Headlines over prose, tables over text, dead ends in one line each. Include plots at key checkpoints (save to `assets/`). Include enough detail to reproduce (parameters, prompts, configs) but stay concise. The `/review-experiment-report` subagent will catch clarity issues — focus on content first.
+Scannable — someone should grasp the full arc in 30 seconds. Headlines over prose, tables over text, dead ends in one line each. Include plots at key checkpoints (save to `assets/`). Include enough detail to reproduce (parameters, prompts, configs) but stay concise. Favor results (numbers, tables, plots) over interpretive prose — keep interpretation to short inline remarks or a few bullets, not dedicated sections. The `/review-experiment-report` subagent will catch clarity issues — focus on content first.
 
 ## Workflow
 

--- a/skill-defs/review-experiment-report/SKILL.md
+++ b/skill-defs/review-experiment-report/SKILL.md
@@ -22,7 +22,7 @@ Flag and fix each of these:
 
 ### 1. Straight to the point
 
-Lead every section with the main result. Cut filler. Interpretation sections should be bulleted one-liners — one claim with its key number per bullet.
+Lead every section with the main result. Cut filler. The report should be dominated by results (numbers, tables, plots), not interpretation. Where interpretation is needed, keep it to short inline remarks or a few bullets — not dedicated Discussion or Implications sections. If a section is mostly prose explaining what results mean, condense it.
 
 - Bad: "We tried alpha values from 0.1 to 10000 using 5-fold CV. The best alpha was 2154. This gave R²=0.86."
 - Good: "Ridge probes achieve R²=0.86 (best alpha=2154 via 5-fold CV)."


### PR DESCRIPTION
## Summary
- Nudge report style guide (research loop + reviewer) to favor results (numbers, tables, plots) over interpretive prose
- Interpretation kept to inline remarks or short bullets, not dedicated Discussion/Implications sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)