### PR TITLE
Extract pod provisioning into reusable skill

### DIFF
--- a/skill-defs/launch-research-pod/SKILL.md
+++ b/skill-defs/launch-research-pod/SKILL.md
@@ -4,18 +4,18 @@ description: >
   Spin up a RunPod GPU pod and launch a research loop on it.
   Argument $ARGUMENTS — path to experiment spec (e.g. experiments/content_orthogonal_gemma2base.md).
 user-invocable: true
-allowed-tools: Bash, AskUserQuestion, Write, Read, Edit, Task
+allowed-tools: Bash, AskUserQuestion, Write, Read, Edit, Agent, Skill
 ---
 
 Spin up a RunPod GPU pod and launch an autonomous research loop on it.
 
 ## Process
 
-1. **Parallel recon**: Launch steps 1a, 1b, and 1c in parallel (three Task tool calls in a single message):
+1. **Parallel recon**: Launch steps 1a, 1b, and 1c in parallel (three Agent tool calls in a single message):
 
-   **1a. Check for dirty/unpushed experiment dependencies** (Task, subagent_type=Explore): "Read the experiment spec at <spec_path>. Identify all referenced source modules, configs, and scripts. Then run `git status --porcelain` and `git log @{u}.. --name-only` and report which dirty or unpushed files are relevant to this experiment. Also suggest a short pod name (2-3 words, kebab-case) based on the experiment title."
+   **1a. Check for dirty/unpushed experiment dependencies** (Agent, subagent_type=Explore): "Read the experiment spec at <spec_path>. Identify all referenced source modules, configs, and scripts. Then run `git status --porcelain` and `git log @{u}.. --name-only` and report which dirty or unpushed files are relevant to this experiment. Also suggest a short pod name (2-3 words, kebab-case) based on the experiment title."
 
-   **1b. Find gitignored data to sync** (Task, subagent_type=Explore): "Read the experiment spec at <spec_path>. Find all referenced data file paths (activations .npz, embeddings, topics .json, results directories, configs). Check which exist locally (follow symlinks) and report each with its size (`du -sh`). These are likely gitignored and will need syncing to the pod."
+   **1b. Find gitignored data to sync** (Agent, subagent_type=Explore): "Read the experiment spec at <spec_path>. Find all referenced data file paths (activations .npz, embeddings, topics .json, results directories, configs). Check which exist locally (follow symlinks) and report each with its size (`du -sh`). These are likely gitignored and will need syncing to the pod."
 
    **1c. List GPUs**: Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py gpus` (Bash tool, runs concurrently with the subagents).
 
@@ -26,35 +26,11 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
      - **Mode**: (a) "Single experiment (/zombuul:launch-research-loop)" — runs one experiment and stops; (b) "Ralph mode (/zombuul:launch-research-ralph)" — iterates until the research goal is met.
      - **Data to sync**: Which data directories to sync (multiSelect), listed with sizes from 1b.
 
-3. **Create the pod**: Use the pod name suggested by 1a (or pick one if it didn't). Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name "<pod_name>" --gpu "<gpu_type_id>"` **in the background** (docker image, volume, and disk size come from config — `~/.claude/zombuul.yaml` or defaults). Parse the SSH IP and port from the output (line like `SSH: ssh root@<IP> -p <PORT> ...`).
+3. **Create the pod**: Use the pod name suggested by 1a (or pick one if it didn't). Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name "<pod_name>" --gpu "<gpu_type_id>"` **in the background** (docker image, volume, and disk size come from config — `~/.claude/zombuul.yaml` or defaults). Parse the SSH IP and port from the output (line like `SSH: ssh root@<IP> -p <PORT> ...`), and the pod ID.
 
-4. **Update SSH config**: After getting the IP and port, add a `Host runpod-<pod_name>` alias to `~/.ssh/config` (where `<pod_name>` is the pod name from step 3). Use the Edit tool to append this block to the end of the file:
-     ```
-     Host runpod-<pod_name>
-         HostName <IP>
-         User root
-         Port <PORT>
-         IdentityFile ~/.ssh/id_ed25519
-         StrictHostKeyChecking no
-     ```
+4. **Provision the pod**: Invoke `/zombuul:provision-pod` with JSON arguments: `{"pod_id": "<pod_id>", "pod_name": "<pod_name>", "ip": "<ip>", "port": "<port>", "spec_path": "<spec_path>", "data_dirs": [<dirs from step 2>]}`. The provision skill handles SSH config, wait-setup, .env sync, spec sync, and data directory sync. Wait for it to complete before proceeding.
 
-5. **Wait for setup + sync data in parallel**: Launch these concurrently — SSH is available before setup finishes, so data transfer overlaps with package installation. Use `run_in_background` for all of them, then wait for all to complete before proceeding.
-
-   - **Wait for setup** (background): `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py wait-setup <pod_id>` (use pod ID from step 3). If setup fails, **do not manually run individual steps** — just re-run `pod_setup.sh` on the pod (it's idempotent).
-   - **Sync experiment spec** (background, REQUIRED — the spec is often not committed/pushed):
-     `ssh runpod-<pod_name> 'mkdir -p /workspace/repo/<spec_parent_dir>' && rsync -az --no-owner --no-group <local_spec_path> runpod-<pod_name>:/workspace/repo/<spec_path>`
-   - **Sync data directories** (background, one per directory from step 2):
-     `rsync -az --no-owner --no-group <local_dir>/ runpod-<pod_name>:/workspace/repo/<remote_dir>/`
-     Note the trailing slashes — this copies *contents* of `local_dir` into `remote_dir`.
-   - **Sync .env** (background, if `.env` exists in working directory):
-     `rsync -az --no-owner --no-group .env runpod-<pod_name>:/workspace/repo/.env`
-
-   **Background processes on the pod** — all four pieces required (`nohup`, `</dev/null`, `&`, `disown`):
-   ```
-   ssh runpod-<pod_name> 'nohup bash /path/to/script.sh </dev/null > /var/log/output.log 2>&1 & disown'
-   ```
-
-6. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it as a background process. Use the command the user chose in step 2 (`/zombuul:launch-research-loop` or `/zombuul:launch-research-ralph`). Pass the full path to the spec file (not `@` syntax):
+5. **Launch the research loop**: Write a launch script locally, SCP it to the pod, then run it as a background process. Use the command the user chose in step 2 (`/zombuul:launch-research-loop` or `/zombuul:launch-research-ralph`). Pass the full path to the spec file (not `@` syntax):
    - Use the **Write tool** to create `/tmp/launch_research.sh` locally with this content (substitute the chosen command and spec path):
      ```
      source ~/.bash_profile
@@ -65,12 +41,12 @@ Spin up a RunPod GPU pod and launch an autonomous research loop on it.
    - Copy it to the pod: `rsync -az --no-owner --no-group /tmp/launch_research.sh runpod-<pod_name>:/tmp/launch_research.sh`
    - Launch as background process: `ssh runpod-<pod_name> 'nohup bash /tmp/launch_research.sh </dev/null > /workspace/research.log 2>&1 & disown'`
 
-7. **Verify**: Check that the claude process is running: `ssh runpod-<pod_name> 'ps aux | grep claude | grep -v grep'`
+6. **Verify**: Check that the claude process is running: `ssh runpod-<pod_name> 'ps aux | grep claude | grep -v grep'`
 
-8. **Report to user**:
+7. **Report to user**:
    - The research loop is running on the pod.
    - SSH command: `ssh runpod-<pod_name>`
    - To watch progress: `tail -f /workspace/research.log`
    - The pod will auto-terminate after the research loop finishes. Run `/zombuul:stop-runpod` to terminate early if needed.
 
-9. **Friction check**: If anything went wrong or was harder than expected and Slack is configured, post a friction report: `{"channel": "$SLACK_CHANNEL_ID", "text": ":warning: *Friction report* (launch-research-pod)\n> <summary>\n> *Severity*: minor/moderate/major\n> *Details*: <1-3 sentences>", "username": "friction-log", "icon_url": "https://dummyimage.com/48x48/ff6b6b/ff6b6b.png"}`. Skip if nothing went wrong.
+8. **Friction check**: If anything went wrong or was harder than expected and Slack is configured, post a friction report: `{"channel": "$SLACK_CHANNEL_ID", "text": ":warning: *Friction report* (launch-research-pod)\n> <summary>\n> *Severity*: minor/moderate/major\n> *Details*: <1-3 sentences>", "username": "friction-log", "icon_url": "https://dummyimage.com/48x48/ff6b6b/ff6b6b.png"}`. Skip if nothing went wrong.

--- a/skill-defs/launch-runpod/SKILL.md
+++ b/skill-defs/launch-runpod/SKILL.md
@@ -3,7 +3,7 @@ name: zombuul:launch-runpod
 description: >
   Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name.
 user-invocable: true
-allowed-tools: Bash, AskUserQuestion, Read, Edit
+allowed-tools: Bash, AskUserQuestion, Read, Edit, Skill
 ---
 
 Spin up a RunPod GPU pod interactively.
@@ -30,21 +30,14 @@ Spin up a RunPod GPU pod interactively.
    - Add `--image "<image>"` only if the user specified a non-default image.
    Use $ARGUMENTS as the pod name if provided, otherwise default to "research". The script auto-detects the repo URL and branch from the current working directory, creates the pod, waits for SSH, extracts Claude Code credentials from Keychain, then SCPs and runs `pod_setup.sh`.
 
-6. **Update SSH config**: After getting the IP and port, add a `Host runpod-<name>` alias to `~/.ssh/config` (where `<name>` is the pod name from step 5). Use the Edit tool to append this block to the end of the file:
-     ```
-     Host runpod-<name>
-         HostName <ip>
-         User root
-         Port <port>
-         IdentityFile ~/.ssh/id_ed25519
-         StrictHostKeyChecking no
-     ```
+6. **Ask about provisioning**: After getting the pod ID, IP, and port from the create output, ask the user via AskUserQuestion:
+   - **"Provision pod"** (Recommended) — waits for setup to complete, configures SSH alias, syncs .env
+   - **"Raw pod"** — just prints SSH info, no provisioning
 
-7. **SCP the project .env**: If a `.env` file exists in the current working directory, copy it to the pod:
-   `scp .env runpod-<name>:/workspace/repo/.env`
+   If the user chooses **Provision**: invoke `/zombuul:provision-pod` with JSON arguments: `{"pod_id": "<pod_id>", "pod_name": "<name>", "ip": "<ip>", "port": "<port>"}`. The provision skill handles SSH config, wait-setup, and .env sync.
 
-8. **Report to the user**:
-   - SSH command: `ssh runpod-<name>`
+   If the user chooses **Raw pod**: report to the user:
+   - SSH command: `ssh root@<ip> -p <port> -i ~/.ssh/id_ed25519`
    - The setup script is running in the background on the pod (clones repo, installs deps). Check `/var/log/pod_setup.log` on the pod for progress.
    - Once setup is done, run `source ~/.bash_profile && cd /workspace/repo && IS_SANDBOX=1 claude --dangerously-skip-permissions --effort high`.
    - If setup fails, don't debug individual steps — just re-run `pod_setup.sh`: `ssh runpod-<name> 'nohup bash /pod_setup.sh <repo_url> <branch> </dev/null > /var/log/pod_setup.log 2>&1 & disown'`. It's idempotent (skips clone if repo exists).

--- a/skill-defs/provision-pod/SKILL.md
+++ b/skill-defs/provision-pod/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: zombuul:provision-pod
+description: >
+  Provision a RunPod pod: wait for setup, configure SSH, sync .env and data.
+  Argument $ARGUMENTS — JSON with keys: pod_id, pod_name, ip, port, and optionally spec_path and data_dirs.
+user-invocable: false
+allowed-tools: Bash, AskUserQuestion, Read, Edit, Agent
+---
+
+Provision a RunPod pod after creation. Handles SSH config, waits for setup to complete, and syncs project files.
+
+## Arguments
+
+`$ARGUMENTS` is a JSON string with these keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `pod_id` | yes | RunPod pod ID |
+| `pod_name` | yes | Pod name (used for SSH alias) |
+| `ip` | yes | SSH IP address |
+| `port` | yes | SSH port |
+| `spec_path` | no | Experiment spec path (triggers spec sync; triggers data recon if `data_dirs` absent) |
+| `data_dirs` | no | Explicit list of local directories to sync (skips recon) |
+
+## Process
+
+1. **Parse arguments**: Parse the JSON from `$ARGUMENTS`. Validate that `pod_id`, `pod_name`, `ip`, and `port` are present.
+
+2. **Update SSH config**: Add a `Host runpod-<pod_name>` alias to `~/.ssh/config`. Use the Edit tool to append this block to the end of the file:
+   ```
+   Host runpod-<pod_name>
+       HostName <ip>
+       User root
+       Port <port>
+       IdentityFile ~/.ssh/id_ed25519
+       StrictHostKeyChecking no
+   ```
+
+3. **Data recon (conditional)**: If `spec_path` is provided but `data_dirs` is NOT:
+   - Launch an Explore agent: "Read the experiment spec at <spec_path>. Find all referenced data file paths (activations .npz, embeddings, topics .json, results directories, configs). Check which exist locally (follow symlinks) and report each with its size (`du -sh`). These are likely gitignored and will need syncing to the pod."
+   - Once the agent returns, ask the user via AskUserQuestion (multiSelect) which data directories to sync, listed with sizes.
+   - Use the user's selection as `data_dirs` for step 4.
+
+4. **Parallel sync + wait**: Launch all of the following concurrently using `run_in_background`, then wait for all to complete:
+
+   - **Wait for setup**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py wait-setup <pod_id>` — polls until pod setup is done. If setup fails, re-run `pod_setup.sh` (it's idempotent).
+   - **Sync .env** (if `.env` exists in current working directory): `rsync -az --no-owner --no-group .env runpod-<pod_name>:/workspace/repo/.env`
+   - **Sync experiment spec** (if `spec_path` provided): `ssh runpod-<pod_name> 'mkdir -p /workspace/repo/<spec_parent_dir>' && rsync -az --no-owner --no-group <spec_path> runpod-<pod_name>:/workspace/repo/<spec_path>`
+   - **Sync data directories** (one per directory from `data_dirs`): `rsync -az --no-owner --no-group <local_dir>/ runpod-<pod_name>:/workspace/repo/<remote_dir>/` — note trailing slashes to copy contents.
+
+5. **Report**: Once all background tasks complete, report:
+   - SSH command: `ssh runpod-<pod_name>`
+   - What was synced (list .env, spec, data dirs as applicable)
+   - Setup status (success or failure with instructions to check `/var/log/pod_setup.log`)


### PR DESCRIPTION
## Summary
- New `provision-pod` skill (non-user-invocable) handles SSH config, wait-setup, .env/spec/data sync
- `launch-runpod` now asks "Provision pod" vs "Raw pod" after creation, delegates to provision-pod
- `launch-research-pod` delegates setup to provision-pod instead of duplicating sync logic

## Test plan
- [ ] `/zombuul:launch-runpod` → choose Provision → verify SSH alias, wait-setup, .env sync
- [ ] `/zombuul:launch-runpod` → choose Raw pod → verify bare SSH info
- [ ] `/zombuul:launch-research-pod <spec>` → verify full flow with data sync via provision-pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)