### PR TITLE
Fix wait-setup timeouts and install all extras

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -110,7 +110,24 @@ retry "create venv" 3 5 uv venv --python "$PYTHON_VERSION" /opt/venvs/research
 # shellcheck disable=SC1091
 source /opt/venvs/research/bin/activate
 cd "$REPO_DIR" || exit 1
-retry "pip install project" 3 10 uv pip install -e .
+# Discover optional dependency groups from pyproject.toml and install all of them.
+# Falls back to base install if parsing fails or no extras exist.
+EXTRAS=""
+if [ -f "$REPO_DIR/pyproject.toml" ]; then
+    EXTRAS=$(python3 -c "
+import tomllib, sys
+with open('$REPO_DIR/pyproject.toml', 'rb') as f:
+    groups = list(tomllib.load(f).get('project', {}).get('optional-dependencies', {}).keys())
+if groups:
+    print(','.join(groups))
+" 2>/dev/null || true)
+fi
+if [ -n "$EXTRAS" ]; then
+    echo "Installing with extras: [$EXTRAS]"
+    retry "pip install project" 3 10 uv pip install -e ".[$EXTRAS]"
+else
+    retry "pip install project" 3 10 uv pip install -e .
+fi
 uv cache clean
 
 # --- git identity ---

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -305,7 +305,7 @@ def setup_status(pod_id: str):
     if not ip:
         print(f"Pod {pod_id} has no public SSH port.")
         return
-    result = ssh_run(ip, port, ["tail", "-5", "/var/log/pod_setup.log"], capture_output=True, text=True, timeout=10)
+    result = ssh_run(ip, port, ["tail", "-5", "/var/log/pod_setup.log"], capture_output=True, text=True, timeout=120)
     if result.returncode == 0:
         print(result.stdout)
     else:
@@ -324,7 +324,7 @@ def wait_for_setup(pod_id: str, timeout: int = 900, poll_interval: int = 15):
     while time.time() - start < timeout:
         done = ssh_run(
             ip, port, "grep -c 'Setup complete' /var/log/pod_setup.log",
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, timeout=120,
         )
         if done.returncode == 0 and done.stdout.strip() != "0":
             elapsed = int(time.time() - start)
@@ -333,7 +333,7 @@ def wait_for_setup(pod_id: str, timeout: int = 900, poll_interval: int = 15):
 
         tail = ssh_run(
             ip, port, "tail -1 /var/log/pod_setup.log",
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, timeout=120,
         )
         if tail.returncode == 0:
             line = tail.stdout.strip()
@@ -349,7 +349,7 @@ def wait_for_setup(pod_id: str, timeout: int = 900, poll_interval: int = 15):
     print(f"ERROR: Setup timed out after {elapsed}s")
     tail = ssh_run(
         ip, port, "tail -5 /var/log/pod_setup.log",
-        capture_output=True, text=True, timeout=10,
+        capture_output=True, text=True, timeout=120,
     )
     if tail.returncode == 0:
         print(f"Last log lines:\n{tail.stdout.strip()}")


### PR DESCRIPTION
## Summary
- SSH timeouts in `wait_for_setup` bumped from 10s to 120s — pod under load causes SSH hangs
- `pod_setup.sh` now discovers all `[project.optional-dependencies]` groups from `pyproject.toml` and installs them all (e.g. `.[dev,test]`), instead of only base deps

## Test plan
- [ ] Launch a pod and verify `wait-setup` doesn't timeout during heavy install
- [ ] Verify pandas (dev dep) is available after setup completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)