### PR TITLE
Make provision-pod skill user-invocable

### DIFF
--- a/skill-defs/provision-pod/SKILL.md
+++ b/skill-defs/provision-pod/SKILL.md
@@ -3,7 +3,7 @@ name: zombuul:provision-pod
 description: >
   Provision a RunPod pod: wait for setup, configure SSH, sync .env and data.
   Argument $ARGUMENTS — JSON with keys: pod_id, pod_name, ip, port, and optionally spec_path and data_dirs.
-user-invocable: false
+user-invocable: true
 allowed-tools: Bash, AskUserQuestion, Read, Edit, Agent
 ---
 


### PR DESCRIPTION
## Summary
- Changed `user-invocable: false` to `true` for the provision-pod skill so it appears in the skills list and can be invoked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)