### PR TITLE
Register provision-pod skill in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,7 @@
         "./skill-defs/launch-research-ralph",
         "./skill-defs/launch-runpod",
         "./skill-defs/pause-runpod",
+        "./skill-defs/provision-pod",
         "./skill-defs/resume-runpod",
         "./skill-defs/review-experiment-report",
         "./skill-defs/setup",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Zombuul
+
+## Skill registration
+
+Skills are NOT auto-discovered. When adding a new skill directory under `skill-defs/`, you MUST also add it to the `skills` array in `.claude-plugin/marketplace.json`. If you forget, the skill won't appear in Claude Code even though the file exists.


### PR DESCRIPTION
## Summary
- `provision-pod` skill existed in `skill-defs/` but was missing from the `skills` array in `.claude-plugin/marketplace.json`, so it never appeared in Claude Code
- Added `CLAUDE.md` documenting that new skills must be registered in `marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)