### PR TITLE
Remove explicit skills list, use auto-discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,20 +5,7 @@
     {
       "name": "zombuul",
       "source": "./",
-      "description": "Autonomous research loops on GPU pods with Claude Code",
-      "skills": [
-        "./skill-defs/check-slack",
-        "./skill-defs/launch-research-loop",
-        "./skill-defs/launch-research-pod",
-        "./skill-defs/launch-research-ralph",
-        "./skill-defs/launch-runpod",
-        "./skill-defs/pause-runpod",
-        "./skill-defs/provision-pod",
-        "./skill-defs/resume-runpod",
-        "./skill-defs/review-experiment-report",
-        "./skill-defs/setup",
-        "./skill-defs/stop-runpod"
-      ]
+      "description": "Autonomous research loops on GPU pods with Claude Code"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Zombuul
 
-## Skill registration
+## Skills
 
-Skills are NOT auto-discovered. When adding a new skill directory under `skill-defs/`, you MUST also add it to the `skills` array in `.claude-plugin/marketplace.json`. If you forget, the skill won't appear in Claude Code even though the file exists.
+Skills are auto-discovered from `skill-defs/`. Each skill is a directory with a `SKILL.md` file containing YAML frontmatter. No manual registration needed — just create the directory and file.


### PR DESCRIPTION
## Summary
- Removes the explicit `skills` array from `marketplace.json` — skills should auto-discover from `skill-defs/` like official plugins do
- The explicit list was a workaround for local skill clashes that's no longer needed
- Updates CLAUDE.md to document auto-discovery

## Test plan
- [ ] Reinstall plugin after merge, verify all 11 skills (including provision-pod) appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)