### PR TITLE
Make python_version configurable

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -3,4 +3,5 @@ disk_gb: 100
 docker_image: "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"
 gpu_count: 1
 cpu_instance_id: "cpu3c-2-4"
+python_version: "3.12"
 template_id: null

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -18,7 +18,7 @@ print = functools.partial(print, flush=True)
 SSH_KEY = "~/.ssh/id_ed25519"
 SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5"]
 USER_CONFIG = "~/.claude/zombuul.yaml"
-VALID_CONFIG_KEYS = {"volume_gb", "disk_gb", "docker_image", "gpu_count", "cpu_instance_id", "template_id"}
+VALID_CONFIG_KEYS = {"volume_gb", "disk_gb", "docker_image", "gpu_count", "cpu_instance_id", "python_version", "template_id"}
 
 
 def load_config() -> dict:
@@ -380,7 +380,7 @@ def main():
     create.add_argument("--image", default=config["docker_image"], help=f"Docker image (default: from config)")
     create.add_argument("--repo-url", default=None, help="Git repo URL to clone on pod (default: current repo's origin)")
     create.add_argument("--branch", default=None, help="Git branch to checkout on pod (default: current branch)")
-    create.add_argument("--python", default="3.12", help="Python version for venv (default: 3.12)")
+    create.add_argument("--python", default=config["python_version"], help=f"Python version for venv (default: from config)")
     create.add_argument("--gpu-count", type=int, default=config["gpu_count"], help=f"Number of GPUs (default: {config['gpu_count']})")
     create.add_argument("--volume-gb", type=int, default=config["volume_gb"], help=f"Volume size in GB (default: {config['volume_gb']})")
     create.add_argument("--disk-gb", type=int, default=config["disk_gb"], help=f"Disk size in GB (default: {config['disk_gb']})")

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -68,6 +68,7 @@ If the user says **yes**, ask about all settings in a single AskUserQuestion cal
 2. **Disk size** (container disk in GB) — offer the current value as "(current)", plus alternatives. Common values: 100, 200, 400.
 3. **GPU count** — offer 1, 2, 4.
 4. **Docker image** — offer the current image as "(current)", plus any newer PyTorch images you know of. The "Other" option (auto-provided by AskUserQuestion) lets them paste a custom image.
+5. **Python version** — offer the current value as "(current)", plus alternatives like 3.11, 3.12, 3.13. This controls the venv Python version on the pod.
 
 Skip `cpu_instance_id` — it's too niche for the interactive flow.
 


### PR DESCRIPTION
## Summary
- Add `python_version` to `defaults.yaml` and `VALID_CONFIG_KEYS`
- CLI `--python` flag now reads default from config instead of hardcoding 3.12
- Setup wizard offers Python version as a customizable option

🤖 Generated with [Claude Code](https://claude.com/claude-code)