### PR TITLE
Add pre-mortem checks and plot preferences to review skills

### DIFF
--- a/skills/review-experiment-report/SKILL.md
+++ b/skills/review-experiment-report/SKILL.md
@@ -67,19 +67,25 @@ If the experiment involves a multi-step procedure, pipeline, or setup where mult
 - The diagram should use concrete examples (specific values, not abstract placeholders) so the reader can trace through what happens step by step.
 - If a diagram already exists, check that it covers all conditions mentioned in the report and uses consistent colors with the results plots.
 
-### 6. Choosing the right presentation
+### 6. Prefer plots over tables
 
-Pick the best format: exact numbers → table; trends/comparisons → plot; one or two values → inline. When referencing a plot, describe the pattern. Table column names should be understandable without context. Define non-standard metrics on first use.
+Default to plots. Tables with more than ~4 rows of numeric results should be a plot instead. Use tables only when exact numbers matter more than patterns (e.g., final metrics, hyperparameter configs).
 
-### 7. Missing context
+### 7. Plot consistency across reports
+
+Check sibling/parent experiment directories for related reports. If found, read their plots and match the format: same chart type, axis ranges, color mapping, condition ordering, and legend style.
+
+### 8. Missing context
 
 If a number is presented without a comparison point (baseline, chance level, ceiling), add one. Isolated numbers are hard to interpret.
 
 ## Process
 
 1. Read the spec, then the report.
-2. For each plot referenced in the report, read the image file and evaluate it against criteria 4-5 above. Plots are the most common source of confusion — axis labels, legends, and color choices that made sense during analysis often don't survive first contact with a reader.
-3. Make a list of all issues found (grouped by criterion above).
-4. Rewrite the report in place, fixing all text issues. Preserve all factual content — you're editing for clarity, not changing results.
-5. For plots that need fixing (bad labels, inconsistent colors, missing context), write and run a replacement plotting script. For missing diagrams (criterion 5), create them.
-6. After rewriting, briefly summarize what you changed.
+2. Check for related reports in sibling or parent experiment directories. If found, read their plots to establish the visual style to match (criterion 7).
+3. For each plot referenced in the report, read the image file and evaluate it against criteria 4-5 and 7 above. Plots are the most common source of confusion — axis labels, legends, and color choices that made sense during analysis often don't survive first contact with a reader.
+4. Flag any tables that should be plots (criterion 6). When replacing a table with a plot, preserve all the data — the plot should convey strictly more than the table did.
+5. Make a list of all issues found (grouped by criterion above).
+6. Rewrite the report in place, fixing all text issues. Preserve all factual content — you're editing for clarity, not changing results.
+7. For plots that need fixing (bad labels, inconsistent colors, missing context) or tables that should become plots, write and run a replacement plotting script. For missing diagrams (criterion 5), create them.
+8. After rewriting, briefly summarize what you changed.

--- a/skills/review-spec/SKILL.md
+++ b/skills/review-spec/SKILL.md
@@ -104,6 +104,17 @@ This is where experiments most often go wrong silently. Flag any of these that a
 - Steps that could fail silently (e.g., empty results, wrong tensor shapes, mismatched task IDs)
 - Missing sanity checks
 
+### 7. Pre-mortem: what could go wrong?
+
+Assume the experiment runs to completion but produces a useless or misleading result. Think adversarially:
+
+- **Confounds**: Could the result be explained by something other than the intended variable? (e.g., topic/length/format artifacts, shared content between conditions)
+- **Ceiling/floor effects**: Could the metric saturate before the manipulation has a chance to show an effect?
+- **Wrong abstraction level**: Is the spec measuring the right thing? (e.g., measuring accuracy when the question is about calibration, or measuring average when the distribution is bimodal)
+- **Null result ambiguity**: If the experiment finds no effect, can we distinguish "no effect exists" from "method wasn't sensitive enough"? Are there positive controls?
+
+For each risk, suggest a concrete mitigation.
+
 ## Output
 
 1. **Pass/fail** per item (one line each)
@@ -134,7 +145,7 @@ Only report code references. Do not review anything else.
 
 Merge the results into a single review:
 
-1. **Pass/fail summary** — one line per checklist item (code reuse, data requirements, parameters, formats/conventions, GPU memory, success criteria, silent failures)
+1. **Pass/fail summary** — one line per checklist item (code reuse, data requirements, parameters, formats/conventions, GPU memory, success criteria, silent failures, pre-mortem risks)
 2. **Code pointer verification** — which references exist, which don't
 3. **Issues** — combined from agents 1 and 2, deduplicated
 4. **Suggested additions** — combined from agents 1 and 2


### PR DESCRIPTION
## Summary
- **review-spec**: New pre-mortem section asking adversarially what could go wrong (confounds, ceiling/floor effects, wrong abstraction level, null result ambiguity)
- **review-experiment-report**: Default to plots over tables; match plot style from related reports for cross-report consistency

## Test plan
- [ ] Run `/review-spec` on an existing spec and verify pre-mortem section appears
- [ ] Run `/review-experiment-report` on a report with tables and verify it flags them

🤖 Generated with [Claude Code](https://claude.com/claude-code)