### PR TITLE
Accept natural language descriptions in run-experiment

### DIFF
--- a/skills/review-spec/SKILL.md
+++ b/skills/review-spec/SKILL.md
@@ -8,9 +8,17 @@ user-invocable: true
 
 Review this experiment spec for practical readiness: $ARGUMENTS
 
+## Proportionality
+
+**Scale review depth to spec complexity.** A 25-line extraction or analysis spec does not need the same scrutiny as a 100-line multi-phase experiment. Before launching agents, read the spec and estimate complexity:
+
+- **Simple** (~25-40 lines, single step, local execution, existing modules): focus on code pointer verification only (Agent 3). Skip Agents 1 and 2 — their checklists add noise for straightforward specs. Return a brief pass/fail on whether the referenced code exists and the parameters are specified.
+- **Medium** (40-80 lines, 2-3 steps, may need GPU): run all three agents but tell Agents 1 and 2 to keep output to pass/fail items only — no "suggested additions" unless something is actually missing.
+- **Complex** (80+ lines, multi-phase, novel methodology): full review as described below.
+
 ## What to do
 
-Read the spec, `README.md`, and `CLAUDE.md`. Then launch **three parallel subagents** (Agent tool, subagent_type="general-purpose"). Each simulates reading the spec with zero prior context — pass only the spec + README + CLAUDE.md contents, nothing else.
+Read the spec, `README.md`, and `CLAUDE.md`. Then launch subagents as appropriate for the complexity level above. For medium and complex specs, launch **three parallel subagents** (Agent tool, subagent_type="general-purpose"). Each simulates reading the spec with zero prior context — pass only the spec + README + CLAUDE.md contents, nothing else.
 
 ### Shared preamble (include in all three prompts)
 

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -1,16 +1,38 @@
 ---
 name: zombuul:run-experiment
 description: >
-  Run an experiment from a spec. Handles pod creation, data sync, execution, and reporting.
-  Argument $ARGUMENTS — path to experiment spec.
+  Run an experiment from a spec or description. If given a path to an existing spec, runs it directly.
+  If given a natural language description, synthesizes a spec first, then runs it.
+  Argument $ARGUMENTS — path to experiment spec OR natural language description of the experiment.
 user-invocable: true
 ---
 
 Run this experiment: $ARGUMENTS
 
+## Phase 0: Determine input type
+
+If `$ARGUMENTS` ends in `.md` and the file exists → it's a spec path. Skip to Phase 1.
+
+Otherwise → it's a natural language description. Spawn a **spec synthesis subagent** (Agent tool, subagent_type="general-purpose", model="opus") with the following prompt:
+
+> Write a concise experiment spec from this description and the conversation context.
+>
+> **Description:** {$ARGUMENTS}
+>
+> **Instructions:**
+> - Read `README.md` and `CLAUDE.md` for codebase conventions and available modules.
+> - Read 2-3 short existing specs under `experiments/` for format reference (the shortest specs are ~25 lines — match that brevity for simple experiments).
+> - Derive an experiment name and path. Nest under an existing experiment if it's a follow-up; otherwise create a new directory.
+> - The spec should include: title, core question, models/data, code pointers to existing modules, parameter values, and steps. Omit background, justification, or anything the executing agent can find in the README.
+> - Scale length to complexity. A single-step analysis or extraction needs ~25 lines. A multi-phase experiment with GPU needs more. Never pad.
+> - Write the spec to `experiments/{name}/{name}_spec.md`.
+> - Return the spec path and a one-paragraph summary of key decisions/assumptions.
+
+When the subagent returns, show the user the spec path and summary. Ask: "Want me to run `/zombuul:review-spec` on this, or proceed?" Do not proceed to Phase 1 until the user confirms.
+
 ## Phase 1: Read spec and launch setup agents
 
-1. **Read the spec** at `$ARGUMENTS`. Determine whether GPU is needed (references to GPU, CUDA, model loading, extraction, training on large models, steering).
+1. **Read the spec** (at the confirmed spec path). Determine whether GPU is needed (references to GPU, CUDA, model loading, extraction, training on large models, steering).
 2. **Save the main repo root**: `MAIN_REPO=$(pwd)`.
 3. **Launch two background subagents in parallel** (both with `model: "opus"`, `run_in_background: true`):
 


### PR DESCRIPTION
## Summary
- `run-experiment` now accepts either a spec path or a natural language description as its argument
- When given a description, spawns a subagent to synthesize a concise spec (calibrated to existing short specs ~25 lines), then offers optional review before proceeding
- `review-spec` now scales review depth to spec complexity: simple specs get code pointer verification only, skipping the heavy checklists

## Test plan
- [ ] `/zombuul:run-experiment experiments/some/spec.md` still works as before
- [ ] `/zombuul:run-experiment train probes on qwen activations with 5k tasks` synthesizes a spec and asks before proceeding
- [ ] `/zombuul:review-spec` on a short spec only runs Agent 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)