### PR TITLE
Add remote mode to run-experiment for disconnect-safe execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,25 @@ And then ask claude to set it up.
 
 Your local Claude Code reads the spec, decides if a GPU pod is needed, sets one up if so, then runs the experiment — baseline, iterations, plots, report. GPU-bound work (extraction, training, steering) runs on the pod via SSH; analysis and plotting run locally. Results are synced back, the pod is paused, and the branch is pushed.
 
+### Remote mode (survive local disconnects)
+
+Pass `--remote` to run the agent *inside* the pod instead of orchestrating from your laptop:
+
+```
+/zombuul:run-experiment experiments/my_question/my_question_spec.md --remote
+```
+
+Your local Claude pushes the branch, spins up a pod with Claude Code + the zombuul plugin installed, syncs the spec and any gitignored data the spec reads, kicks off `claude -p '/zombuul:run-experiment <spec>'` inside the pod under `nohup ... & disown`, and hands off. The on-pod agent commits and pushes `experiments/<name>/running_log.md` after each step so you can `git fetch` to see progress. When the agent exits, the pod auto-pauses.
+
+Claude Code is **only** installed on the pod in remote mode. Default (local) mode uses the pod as a dumb SSH target.
+
 ## Commands
 
 | Command | What it does |
 |---------|-------------|
-| `/zombuul:run-experiment` | Run an experiment from a spec. Handles pod creation, data sync, remote/local execution, and reporting. |
+| `/zombuul:run-experiment` | Run an experiment from a spec. Handles pod creation, data sync, remote/local execution, and reporting. Pass `--remote` to run the agent inside the pod. |
 | `/zombuul:review-spec` | Review an experiment spec for completeness before running it. |
-| `/zombuul:launch-runpod` | Spin up a pod without launching an experiment. Gives you an SSH command and a ready environment. |
+| `/zombuul:launch-runpod` | Spin up a pod without launching an experiment. Pass `--remote` as a second arg to also install Claude Code + the zombuul plugin on the pod. |
 | `/zombuul:provision-pod` | Provision a pod: configure SSH, sync .env and data. Called by `run-experiment` automatically. |
 | `/zombuul:pause-runpod` | Pause a pod (stop GPU billing, keep disk). |
 | `/zombuul:resume-runpod` | Resume a paused pod. |

--- a/scripts/launch_on_pod.sh
+++ b/scripts/launch_on_pod.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Usage: launch_on_pod.sh <branch> <spec_path>
+#
+# Runs an on-pod zombuul agent for a single experiment and pauses the pod
+# when the agent exits (success, failure, or signal). Trap fires on any EXIT
+# except SIGKILL, so the pod won't keep billing if the agent crashes.
+set -u
+
+BRANCH="${1:?Usage: launch_on_pod.sh <branch> <spec_path>}"
+SPEC_PATH="${2:?Usage: launch_on_pod.sh <branch> <spec_path>}"
+
+# Load env (RUNPOD_POD_ID, RUNPOD_API_KEY, HF_TOKEN, GH_TOKEN, etc.) before
+# registering the trap so pause_pod has access to them.
+source ~/.bash_profile
+
+pause_pod() {
+    curl -s -H "Content-Type: application/json" \
+        -d "{\"query\": \"mutation { podStop(input: {podId: \\\"$RUNPOD_POD_ID\\\"}) { id desiredStatus } }\"}" \
+        "https://api.runpod.io/graphql?api_key=$RUNPOD_API_KEY"
+}
+trap pause_pod EXIT
+
+cd /workspace/repo
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+export IS_SANDBOX=1
+claude --dangerously-skip-permissions -p "/zombuul:run-experiment $SPEC_PATH" > /workspace/agent.log 2>&1

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-# Usage: bash pod_setup.sh <repo_url> [branch] [python_version]
+# Usage: bash pod_setup.sh <repo_url> [branch] [python_version] [install_claude]
 # Generic pod bootstrap for zombuul research loops.
 # Tokens come from container env vars (/proc/1/environ), with .env as fallback.
+#
+# install_claude: "true" to install Claude Code + zombuul plugin (for remote-mode
+# experiments where the pod itself runs an agent). Default "false" — local-mode
+# setups only need the repo + Python env, not the agent.
 set -o pipefail
 
-REPO_URL="${1:?Usage: bash pod_setup.sh <repo_url> [branch] [python_version]}"
+REPO_URL="${1:?Usage: bash pod_setup.sh <repo_url> [branch] [python_version] [install_claude]}"
 BRANCH="${2:-main}"
 PYTHON_VERSION="${3:-3.12}"
+INSTALL_CLAUDE="${4:-false}"
 REPO_DIR="/workspace/repo"
 SETUP_FAILURES=()
 
@@ -104,21 +109,33 @@ retry "clone repo" 3 15 clone_repo
 cd "$REPO_DIR" || exit 1
 git checkout "$BRANCH" || git checkout -b "$BRANCH" "origin/$BRANCH"
 
-# --- Claude Code ---
+# --- Claude Code + zombuul plugin ---
 
-install_claude() {
-    if command -v claude &>/dev/null; then
-        echo "Claude Code already installed."
-        return 0
+if [ "$INSTALL_CLAUDE" = "true" ]; then
+    install_claude() {
+        if command -v claude &>/dev/null; then
+            echo "Claude Code already installed."
+            return 0
+        fi
+        curl -fsSL https://claude.ai/install.sh | bash
+    }
+    retry "install Claude Code" 3 15 install_claude
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v claude &>/dev/null; then
+        echo "FATAL: claude not found on PATH after install."
+        SETUP_FAILURES+=("claude binary not found")
     fi
-    curl -fsSL https://claude.ai/install.sh | bash
-}
-retry "install Claude Code" 3 15 install_claude
-export PATH="$HOME/.local/bin:$PATH"
 
-if ! command -v claude &>/dev/null; then
-    echo "FATAL: claude not found on PATH after install."
-    SETUP_FAILURES+=("claude binary not found")
+    install_zombuul() {
+        # Remove stale marketplace if present (idempotent re-install)
+        claude plugin marketplace remove ogilg-marketplace 2>/dev/null || true
+        claude plugin marketplace add ogilg/zombuul || return 1
+        claude plugin install zombuul@ogilg-marketplace || return 1
+    }
+    retry "install zombuul plugin" 3 10 install_zombuul
+else
+    echo "Skipping Claude Code install (INSTALL_CLAUDE=false)."
 fi
 
 # --- caches outside NFS ---
@@ -186,16 +203,6 @@ if [ -n "$HF_TOKEN" ]; then
 fi
 
 # gh auth already done above (before clone)
-
-# --- zombuul plugin ---
-
-install_zombuul() {
-    # Remove stale marketplace if present (idempotent re-install)
-    claude plugin marketplace remove ogilg-marketplace 2>/dev/null || true
-    claude plugin marketplace add ogilg/zombuul || return 1
-    claude plugin install zombuul@ogilg-marketplace || return 1
-}
-retry "install zombuul plugin" 3 10 install_zombuul
 
 # --- .bash_profile ---
 

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -191,22 +191,24 @@ def get_repo_url() -> str:
     sys.exit(1)
 
 
-def setup_pod(ip: str, port: int, repo_url: str, branch: str, python_version: str = "3.12"):
+def setup_pod(ip: str, port: int, repo_url: str, branch: str, python_version: str = "3.12", install_claude: bool = False):
     setup_script = find_setup_script()
 
     print("  Copying pod_setup.sh...")
     scp_to_pod(ip, port, setup_script, "/pod_setup.sh")
 
-    creds_file = extract_claude_credentials()
-    if creds_file:
-        print("  Copying Claude Code credentials...")
-        ssh_run(ip, port, ["mkdir", "-p", "/root/.claude"], capture_output=True, text=True, check=True)
-        scp_to_pod(ip, port, creds_file, "/root/.claude/.credentials.json")
-    else:
-        print("  WARNING: No Claude Code credentials found, skipping auth.")
+    if install_claude:
+        creds_file = extract_claude_credentials()
+        if creds_file:
+            print("  Copying Claude Code credentials...")
+            ssh_run(ip, port, ["mkdir", "-p", "/root/.claude"], capture_output=True, text=True, check=True)
+            scp_to_pod(ip, port, creds_file, "/root/.claude/.credentials.json")
+        else:
+            print("  WARNING: No Claude Code credentials found, skipping auth.")
 
-    print(f"  Running pod_setup.sh in background (repo: {repo_url}, branch: {branch}, python: {python_version})...")
-    cmd = f"nohup bash /pod_setup.sh {shlex.quote(repo_url)} {shlex.quote(branch)} {shlex.quote(python_version)} </dev/null > /var/log/pod_setup.log 2>&1 & disown"
+    install_claude_flag = "true" if install_claude else "false"
+    print(f"  Running pod_setup.sh in background (repo: {repo_url}, branch: {branch}, python: {python_version}, install_claude: {install_claude_flag})...")
+    cmd = f"nohup bash /pod_setup.sh {shlex.quote(repo_url)} {shlex.quote(branch)} {shlex.quote(python_version)} {shlex.quote(install_claude_flag)} </dev/null > /var/log/pod_setup.log 2>&1 & disown"
     ssh_run(ip, port, cmd, capture_output=True, text=True)
     print("  Setup running. Check /var/log/pod_setup.log on the pod.")
 
@@ -219,7 +221,7 @@ def list_gpus():
         print(f"  {gpu['id']:45s} {gpu['memoryInGb']}GB")
 
 
-def create_pod(name: str, gpu_type_id: str | None, image_name: str, repo_url: str, branch: str, *, python_version: str = "3.12", volume_gb: int = 100, disk_gb: int = 200, gpu_count: int = 1, cpu_instance_id: str = "cpu3c-2-4", template_id: str | None = None):
+def create_pod(name: str, gpu_type_id: str | None, image_name: str, repo_url: str, branch: str, *, python_version: str = "3.12", volume_gb: int = 100, disk_gb: int = 200, gpu_count: int = 1, cpu_instance_id: str = "cpu3c-2-4", template_id: str | None = None, install_claude: bool = False):
     kind = gpu_type_id or "CPU-only"
     if template_id:
         print(f"Creating pod '{name}' with {kind} (template: {template_id})...")
@@ -265,7 +267,7 @@ def create_pod(name: str, gpu_type_id: str | None, image_name: str, repo_url: st
     print(f"  SSH: ssh root@{ip} -p {port} -i {SSH_KEY}")
 
     try:
-        setup_pod(ip, port, repo_url, branch, python_version)
+        setup_pod(ip, port, repo_url, branch, python_version, install_claude=install_claude)
     except Exception as e:
         print(f"  WARNING: Setup failed: {e}")
         print(f"  Pod is still running. SSH in and run setup manually.")
@@ -380,6 +382,7 @@ def main():
     create.add_argument("--volume-gb", type=int, default=config["volume_gb"], help=f"Volume size in GB (default: {config['volume_gb']})")
     create.add_argument("--disk-gb", type=int, default=config["disk_gb"], help=f"Disk size in GB (default: {config['disk_gb']})")
     create.add_argument("--template-id", default=config.get("template_id"), help="RunPod template ID (default: from config)")
+    create.add_argument("--install-claude", action="store_true", help="Install Claude Code + zombuul plugin on the pod (for remote-mode experiments where the pod runs its own agent). Default off.")
 
     pause = sub.add_parser("pause", help="Pause a pod (stop GPU billing, keep disk)")
     pause.add_argument("pod_id")
@@ -417,6 +420,7 @@ def main():
             disk_gb=args.disk_gb, gpu_count=args.gpu_count,
             cpu_instance_id=config["cpu_instance_id"],
             template_id=args.template_id,
+            install_claude=args.install_claude,
         )
     elif args.command == "pause":
         pause_pod(args.pod_id)

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: zombuul:launch-runpod
 description: >
-  Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name.
+  Spin up a RunPod GPU pod. Argument $ARGUMENTS — optional pod name, optionally
+  followed by `--remote` to install Claude Code + zombuul plugin on the pod
+  (needed when the pod itself will run an agent, not just receive SSH commands).
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion, Read, Edit, Skill
 ---
 
 Spin up a RunPod GPU pod interactively.
+
+## Arguments
+
+`$ARGUMENTS` is a whitespace-separated list: `[pod_name] [--remote]`.
+
+- `pod_name` (optional): short kebab-case pod name. Default `research`.
+- `--remote` (optional flag): if present, pass `--install-claude` to the create command. This installs Claude Code and the zombuul plugin on the pod so an agent can run *inside* the pod (used by `/zombuul:run-experiment <spec> --remote`). Omit for the default case where your local Claude drives the pod over SSH.
 
 ## Process
 
@@ -28,7 +37,8 @@ Spin up a RunPod GPU pod interactively.
    - GPU: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <name> --gpu "<gpu_type_id>" --gpu-count <n>`
    - CPU: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <name> --cpu`
    - Add `--image "<image>"` only if the user specified a non-default image.
-   Use $ARGUMENTS as the pod name if provided, otherwise default to "research". The script auto-detects the repo URL and branch from the current working directory, creates the pod, waits for SSH, extracts Claude Code credentials from Keychain, then SCPs and runs `pod_setup.sh`.
+   - Add `--install-claude` if the caller passed `--remote` in `$ARGUMENTS`.
+   Use the pod name from $ARGUMENTS if provided, otherwise default to "research". The script auto-detects the repo URL and branch from the current working directory, creates the pod, waits for SSH, and SCPs `pod_setup.sh`. Claude Code credentials are only copied and installed when `--install-claude` is set.
 
 6. **Ask about provisioning**: After getting the pod ID, IP, and port from the create output, ask the user via AskUserQuestion:
    - **"Provision pod"** (Recommended) — waits for setup to complete, configures SSH alias, syncs .env

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -3,21 +3,31 @@ name: zombuul:run-experiment
 description: >
   Run an experiment from a spec or description. If given a path to an existing spec, runs it directly.
   If given a natural language description, synthesizes a spec first, then runs it.
-  Argument $ARGUMENTS — path to experiment spec OR natural language description of the experiment.
+  Argument $ARGUMENTS — `<spec_path_or_description> [--remote]`. Pass `--remote` to execute
+  autonomously on a GPU pod (survives local disconnects); otherwise runs local-first.
 user-invocable: true
 ---
 
 Run this experiment: $ARGUMENTS
 
-## Phase 0: Determine input type
+## Execution modes (pick one before starting)
 
-If `$ARGUMENTS` ends in `.md` and the file exists → it's a spec path. Skip to Phase 1.
+Check `$IS_SANDBOX` and `$ARGUMENTS`:
 
-Otherwise → it's a natural language description. Spawn a **spec synthesis subagent** (Agent tool, subagent_type="general-purpose", model="opus") with the following prompt:
+- **On-pod mode** — if the `IS_SANDBOX=1` env var is set, you are already inside a GPU pod that was launched by a remote-mode invocation. Jump to [On-pod execution](#on-pod-execution). Do not read the rest of this document first.
+- **Remote-launcher mode** — if `$ARGUMENTS` contains the flag `--remote` (strip it before treating the remainder as the spec path/description), go to [Remote-launcher execution](#remote-launcher-execution).
+- **Local mode** — default. `$ARGUMENTS` has no `--remote` flag and `IS_SANDBOX` is unset. Go to [Local execution](#local-execution).
+
+## Phase 0: Determine input type (all modes)
+
+After identifying the mode, parse what's left of `$ARGUMENTS`:
+
+- Ends in `.md` and the file exists → spec path. Skip spec synthesis.
+- Otherwise → natural language description. Spawn a **spec synthesis subagent** (Agent tool, subagent_type="general-purpose", model="opus") with the following prompt:
 
 > Write a concise experiment spec from this description and the conversation context.
 >
-> **Description:** {$ARGUMENTS}
+> **Description:** {$ARGUMENTS (minus `--remote`)}
 >
 > **Instructions:**
 > - Read `README.md` and `CLAUDE.md` for codebase conventions and available modules.
@@ -28,9 +38,11 @@ Otherwise → it's a natural language description. Spawn a **spec synthesis suba
 > - Write the spec to `experiments/{name}/{name}_spec.md`.
 > - Return the spec path and a one-paragraph summary of key decisions/assumptions.
 
-When the subagent returns, show the user the spec path and summary. Ask: "Want me to run `/zombuul:review-spec` on this, or proceed?" Do not proceed to Phase 1 until the user confirms.
+When the subagent returns, show the user the spec path and summary. Ask: "Want me to run `/zombuul:review-spec` on this, or proceed?" Do not proceed until the user confirms.
 
-## Phase 1: Read spec and launch setup agents
+## Local execution
+
+### Phase 1: Read spec and launch setup agents
 
 1. **Read the spec** (at the confirmed spec path). Determine whether GPU is needed (references to GPU, CUDA, model loading, extraction, training on large models, steering).
 2. **Save the main repo root**: `MAIN_REPO=$(pwd)`.
@@ -52,23 +64,96 @@ When the subagent returns, show the user the spec path and summary. Ask: "Want m
 
 4. **Wait for both agents to complete** before proceeding.
 
-## Phase 2: Enter worktree and set up
+### Phase 2: Enter worktree and set up
 
 1. **Enter a worktree**: use the `EnterWorktree` tool with name `{experiment_name}` (derived from the spec path, e.g., `experiments/foo/foo_spec.md` → name `foo`).
 2. **Run the symlink commands** returned by the symlink discovery agent. Verify the experiment's input files are accessible.
 3. **Set up infrastructure** if GPU needed:
    - If the infrastructure agent found a running pod, use it.
-   - Otherwise: invoke `/zombuul:launch-runpod` to create and provision a pod. After it completes, sync experiment data via `/zombuul:provision-pod`, passing `data_dirs` explicitly (inferred from the spec) to skip interactive recon.
+   - Otherwise: invoke `/zombuul:launch-runpod` (local mode — do NOT pass `remote`, the pod is just an SSH target). After it completes, sync experiment data via `/zombuul:provision-pod`, passing `data_dirs` explicitly (inferred from the spec) to skip interactive recon.
    - Do NOT ask the user for GPU choice, data dirs, etc. Make reasonable choices. Only ask if truly blocked.
+
+Continue to [Execution model](#execution-model) and [Workflow](#workflow).
+
+## Remote-launcher execution
+
+You are **not** running the experiment — you are setting up a pod that will run it autonomously, then handing off. The user wants this because their laptop may go offline.
+
+### R1: Read spec, recon data, push branch (concurrent)
+
+1. **Read the spec** at the confirmed spec path.
+2. **Launch in parallel** (one `run_in_background` Bash call for the push, one Agent call for the recon):
+   - **Data recon subagent** (Agent, subagent_type="general-purpose", model="opus"): "Read the experiment spec at <spec_path>. Find every data path it references (activations .npz, embeddings, topics .json, results directories, configs, probe weights, concept vectors). For each: check whether it exists locally (follow symlinks), whether it's gitignored, and report size (`du -sh`). Return a structured list: `path | exists? | gitignored? | size`. The experiment will run on a GPU pod with only what git provides plus what we explicitly sync — anything gitignored that the spec reads must appear in the sync list."
+   - **Push the branch**: commit any relevant unstaged changes (ask before broad commits), then `git push -u origin HEAD`. The pod clones from the remote, so unpushed work is invisible.
+3. **Wait for both**, then **decide `data_dirs`**: gitignored paths the spec reads (not writes) are the default sync set. Do not ask the user; err toward including ambiguous directories — a too-small sync is a silent failure on the pod. Capture the branch name.
+
+### R2: Pod setup
+
+1. **Reuse or create**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py list`. If a suitable pod is already running with claude installed (verify with `ssh runpod-<name> 'command -v claude'`), reuse it. Otherwise, invoke `/zombuul:launch-runpod <pod_name> --remote` — the `--remote` flag causes Claude Code + the zombuul plugin to be installed on the pod. Pick a distinctive 2-3 word kebab-case name based on the experiment.
+2. **Provision**: invoke `/zombuul:provision-pod` with `{"pod_id": ..., "pod_name": ..., "ip": ..., "port": ..., "spec_path": "<spec_path>", "data_dirs": [<from R1>]}`. Wait for completion. `provision-pod`'s `wait-setup` surfaces any setup failures — if it reports `claude binary not found`, re-run setup in remote mode via `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <same> ... --install-claude` (or re-invoke `/zombuul:launch-runpod <pod_name> --remote`).
+
+### R3: Launch the on-pod agent
+
+1. **Copy the launch script to the pod**: `scp ${CLAUDE_PLUGIN_ROOT}/scripts/launch_on_pod.sh runpod-<name>:/tmp/launch_on_pod.sh`
+2. **Launch under nohup + disown** with branch and spec path as positional args:
+   `ssh runpod-<name> 'chmod +x /tmp/launch_on_pod.sh && nohup /tmp/launch_on_pod.sh <branch> <spec_path> </dev/null > /workspace/launch.log 2>&1 & disown'`
+3. **Verify the claude process is running**: `ssh runpod-<name> 'ps aux | grep claude | grep -v grep'`.
+
+The script sources `~/.bash_profile` (for tokens), registers a `trap pause_pod EXIT` so the pod auto-pauses on any agent exit including crashes, then runs `claude -p '/zombuul:run-experiment <spec>'` with `IS_SANDBOX=1`. See `scripts/launch_on_pod.sh` for the full script.
+
+### R4: Hand off to the user
+
+Report:
+- Pod name, SSH command, branch name.
+- Monitoring commands:
+  - `git fetch origin <branch> && git log origin/<branch> --oneline -- experiments/<name>/` — see running-log commits as they land.
+  - `ssh runpod-<name> 'tail -f /workspace/agent.log'` — live stdout of the on-pod agent.
+- Expected behavior: pod auto-pauses when the agent exits (trap handles crashes too). Results land on the `<branch>` branch as commits. `experiments/<name>/running_log.md` is the legible progress log.
+
+Then stop. Do NOT enter any monitoring loop — the user's explicit motivation for remote mode is that they may be offline.
+
+## On-pod execution
+
+You are inside a GPU pod. `IS_SANDBOX=1` is set. Everything you need to run the experiment is already here: the repo is cloned at `/workspace/repo`, `.env` is synced, the spec is at `$ARGUMENTS`, and `data_dirs` specified at launch time have been synced under `/workspace/repo/`. Do NOT:
+
+- Create pods or call any `runpod_ctl.py` command.
+- Invoke `/zombuul:launch-runpod`, `/zombuul:provision-pod`, or `/zombuul:run-experiment` recursively (no `remote` token handling — you're the terminal point).
+- Use `EnterWorktree`. Work directly in `/workspace/repo` on the current branch.
+
+### OP1: Setup
+
+1. **Confirm context**: `pwd` should be `/workspace/repo`. `git branch --show-current` should show the experiment branch. If not, `git checkout <branch>`.
+2. **Read the spec** at the path passed in `$ARGUMENTS`.
+3. **Verify data presence**: for every gitignored data path the spec references, check it exists on the pod (`ls -la <path>`). If anything critical is missing, append a MISSING DATA block to `experiments/<name>/running_log.md`, commit+push, and stop — don't try to work around missing data by provisioning more infrastructure.
+4. **Create scripts workspace, report skeleton, and running log** (see [Directory structure](#directory-structure) below).
+
+### OP2: Run + log + push
+
+Execute the experiment workflow ([Workflow](#workflow) steps 3–5) with two differences:
+
+- **Every step appends to `running_log.md`** (you'd do this in any mode). Additionally, after each step:
+  `git add experiments/<name>/ && git diff --cached --quiet || (git commit -m "log: <brief>" && git push origin HEAD)`
+  The `--quiet` check skips empty commits when no files actually changed (e.g., a no-op step). `git add experiments/<name>/` picks up anything under the experiment dir, including newly-created subdirs. This is what lets the user's local Claude check progress from a fresh fetch. Squash noise later — clarity now beats tidy history.
+- **GPU-bound and CPU-bound commands both run locally on the pod.** No SSH. No rsync-back. Everything lives here.
+
+Keep commits small and labeled (`log: <step>`, `result: <step>`, `fix: <what>`). Do not force-push.
+
+### OP3: Finish
+
+1. Run `/zombuul:review-experiment-report` via an Agent subagent on the report path.
+2. Final commit + push of report, plots, scripts, data artifacts (respect `.gitignore`; large files that aren't already gitignored should be added to `.gitignore` rather than committed).
+3. Exit cleanly. The launch script will pause the pod automatically.
 
 ## Execution model
 
-**Remote vs local execution awareness:**
+**Local mode — remote vs local command awareness:**
 - GPU-bound commands (model loading, extraction, training, steering) → SSH to pod: `ssh runpod-<name> 'cd /workspace/repo && python -m ...'`
 - CPU-bound commands (analysis, plotting, fitting) → run locally
 - Results from pod need to be synced back: `rsync -az runpod-<name>:/workspace/repo/<results_path> <local_path>`
 
-**Non-blocking execution:**
+**On-pod mode:** everything runs locally on the pod. No SSH, no rsync.
+
+**Non-blocking execution (local mode):**
 - Long-running scripts (training, extraction, generation) should use `run_in_background` on the Bash tool
 - Remote execution via SSH also uses `run_in_background`
 - While waiting: prepare next steps, write analysis code, set up plotting scripts
@@ -130,7 +215,7 @@ Image references in the report use relative paths: `![description](assets/plot_f
 
 ### Running log
 
-Create `running_log.md` in the experiment directory. Append to this after every completed step — script outputs, intermediate numbers, observations, errors. This is for recovery if the session dies — do not re-read it during the session. Use your in-context memory for what you've done so far.
+Create `running_log.md` in the experiment directory. Append to this after every completed step — script outputs, intermediate numbers, observations, errors. In on-pod mode, this is also the user's only real-time progress window, so append aggressively (every command, every result) and commit+push after each append. This is for recovery if the session dies — do not re-read it during the session. Use your in-context memory for what you've done so far.
 
 ## Scripts workspace
 
@@ -150,10 +235,10 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 
 ## Workflow
 
-1. **Setup** (Phase 1 + Phase 2 above).
+1. **Setup** (Phase 1 + Phase 2 for local mode; R1–R4 for remote-launcher; OP1 for on-pod).
 2. **Read the spec.** Set up infrastructure.
 3. Create scripts workspace, report skeleton, and running log.
 4. Run baseline, then iterate. Log each step to the running log. Update the report at major milestones with plots. If an approach fails, log it and pivot.
 5. **Review the report.** Launch a subagent (Agent tool, subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to `report.md`. Do not skip this step.
-6. **Sync results.** If a pod was used: sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
-7. **Commit and push.** Commit all outputs — reports, plots, scripts, data files (scores, configs, JSON results). Push: `git push -u origin HEAD`. Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing.
+6. **Sync results** (local mode only, if a pod was used): sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
+7. **Commit and push.** Commit all outputs — reports, plots, scripts, data files (scores, configs, JSON results). Push: `git push -u origin HEAD`. Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing. (In on-pod mode you've already been pushing incrementally — this final push just tops it off.)


### PR DESCRIPTION
## Summary

- `/zombuul:run-experiment <spec> --remote` now installs Claude Code on the pod and runs the agent there, so experiments survive local disconnects.
- Claude Code is **only** installed on the pod when `--remote` is set — default (local) mode no longer installs it.
- On-pod agent commits and pushes `experiments/<name>/running_log.md` after each step so local Claude can monitor progress via `git fetch`.
- Pod auto-pauses on any agent exit via a bash `trap EXIT` in the shipped `scripts/launch_on_pod.sh` (covers crashes and signals, not just clean exits).

## Changes

- `pod_setup.sh`: gate Claude + zombuul plugin install behind `INSTALL_CLAUDE=true` (new 4th positional arg).
- `runpod_ctl.py`: `--install-claude` flag on `create`, plumbed through `create_pod` → `setup_pod`. Credentials only copied when set.
- `launch-runpod` skill: accept `--remote` as a second arg.
- `run-experiment` skill: three branches — local (unchanged), remote-launcher (`--remote` token), on-pod (`IS_SANDBOX=1`). Data recon + branch push run concurrently. Empty-commit guard on the on-pod log loop.
- `scripts/launch_on_pod.sh` (new): takes `<branch> <spec_path>`, sources `~/.bash_profile`, registers `trap pause_pod EXIT`, runs `claude -p '/zombuul:run-experiment <spec>'` with `IS_SANDBOX=1`.

## Test plan

- [ ] Local-mode run: `/zombuul:run-experiment <spec>` provisions a pod without claude installed (check `/var/log/pod_setup.log` for the skip message).
- [ ] Remote-mode run: `/zombuul:run-experiment <spec> --remote` launches on-pod agent, pushes running-log commits to the branch, pod pauses when done.
- [ ] Crash path: kill the on-pod claude process mid-run, confirm pod pauses via the EXIT trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)