### PR TITLE
Add /zombuul:babysit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Claude Code is **only** installed on the pod in remote mode. Default (local) mod
 | `/zombuul:review-spec` | Review an experiment spec for completeness before running it. |
 | `/zombuul:launch-runpod` | Spin up a pod without launching an experiment. Pass `--remote` as a second arg to also install Claude Code + the zombuul plugin on the pod. |
 | `/zombuul:provision-pod` | Provision a pod: configure SSH, sync .env and data. Called by `run-experiment` automatically. |
+| `/zombuul:babysit` | Monitor a long-running job on a pod. Checks every 5 min, restarts on crash, pauses when done. |
 | `/zombuul:pause-runpod` | Pause a pod (stop GPU billing, keep disk). |
 | `/zombuul:resume-runpod` | Resume a paused pod. |
 | `/zombuul:review-experiment-report` | Review and rewrite a research report for clarity. Called by `run-experiment` at the end. |

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: zombuul:babysit
+description: >
+  Monitor a long-running job on a RunPod GPU pod. Checks every 5 min, restarts on crash, pauses pod when done.
+  Argument $ARGUMENTS — `<pod_name> <description of what's running>`.
+  Use when a GPU job is expected to take >10 min and may crash (I/O errors, OOM, SSH timeouts).
+  The description should say what's running and how to tell when it's done (e.g., "E1c extraction — 121 conditions in activations/qwen35_122b_ood/e1c/").
+user-invocable: true
+---
+
+Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning up when done.
+
+## Arguments
+
+`$ARGUMENTS` is `<pod_name> <description>`. The first whitespace-delimited token is the pod name (must match an SSH alias `runpod-<pod_name>`). Everything after it is a natural-language description of what's running and how to tell when it's done.
+
+## Process
+
+1. **Parse arguments.** Split into pod_name and description. If either is empty, show usage and stop.
+
+2. **Snapshot the running command.** SSH to the pod and capture what's running:
+   ```
+   ssh runpod-<pod_name> 'ps aux | grep python | grep -v grep'
+   ```
+   Save this output — it goes into the cron prompt so the babysitter agent knows what to restart.
+
+3. **Create the cron job.** Use `CronCreate` with cron `*/5 * * * *` (every 5 min), recurring: true. The prompt must be **completely self-contained** — the cron agent has no conversation history. Build it from this template:
+
+   ```
+   You are babysitting a GPU job on pod "{pod_name}" (SSH: `runpod-{pod_name}`).
+
+   **What's running:** {description}
+   **Last known command:** {snapshot from step 2}
+
+   ## Check
+
+   1. `ssh runpod-{pod_name} 'ps aux | grep python | grep -v grep'`
+
+   2. **If alive:** Check progress from the description (count output files, tail logs, etc.). Report one line: "{N}/{total} done" or similar.
+
+   3. **If dead:**
+      a. Check logs: `ssh runpod-{pod_name} 'tail -30 /workspace/repo/<likely_log_path>'`
+      b. Diagnose (OOM? I/O error? completed successfully?).
+      c. If completed successfully → go to step 4.
+      d. If crashed → restart using the last known command above (adjust working dir, log path as needed). Report what happened.
+
+   4. **If done** (all expected outputs exist per the description):
+      a. Report completion.
+      b. Pause the pod: invoke `/zombuul:pause-runpod {pod_name}`.
+      c. Cancel this cron job: use `CronList` to find the job whose prompt mentions "{pod_name}", then `CronDelete <id>`.
+
+   Keep output to 1-3 lines unless something went wrong.
+   ```
+
+4. **Run the first check immediately** — execute the same SSH process check inline so the user gets instant feedback. Don't wait for the first cron tick.
+
+5. **Report:** Show the cron job ID, what it's monitoring, and `CronDelete <id>` to cancel.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -158,10 +158,16 @@ Keep commits small and labeled (`log: <step>`, `result: <step>`, `fix: <what>`).
 **On-pod mode:** everything runs locally on the pod. No SSH, no rsync.
 
 **Non-blocking execution (local mode):**
-- Long-running scripts (training, extraction, generation) should use `run_in_background` on the Bash tool
-- Remote execution via SSH also uses `run_in_background`
-- While waiting: prepare next steps, write analysis code, set up plotting scripts
-- You get notified when background tasks complete — process results then
+- Short commands (<10 min): use `run_in_background` on the Bash tool. You get notified when they complete.
+- While waiting: prepare next steps, write analysis code, set up plotting scripts.
+
+**Babysitting long GPU jobs (local mode only):**
+For GPU jobs expected to take more than ~10 minutes, use nohup + babysit instead of `run_in_background`. This handles crash recovery automatically.
+
+1. Launch the job so it survives SSH disconnect:
+   `ssh runpod-<name> 'cd /workspace/repo && nohup python -u -m <module> > <log_path> 2>&1 & disown'`
+2. Invoke `/zombuul:babysit <pod_name> <description>` — this sets up a cron job that checks every 5 min, restarts on crash, and pauses the pod when done.
+3. You are free to work on other tasks while the babysitter monitors. It will report progress and any issues to the conversation.
 
 **Audit on launch:**
 When you launch a long-running job (extraction, training, generation, steering), immediately spawn an audit subagent (Agent tool, subagent_type="general-purpose", model="opus") in the background. The subagent checks the setup independently — it should not trust your assumptions. Pass it the spec and the paths to all data/config files being used. The subagent should:


### PR DESCRIPTION
## Summary
- New `/zombuul:babysit` skill — monitors a long-running GPU job on a pod via CronCreate (every 5 min), restarts on crash, pauses pod when done
- Integrated into run-experiment's local mode execution model for jobs >10 min
- Updated README commands table

## Design
Intentionally minimal — the cron prompt is natural language, the agent uses judgment to check progress, diagnose crashes, restart, and decide when done. No structured flags. The skill snapshots the running command at invocation time so the cron agent knows what to restart.

## Test plan
- [ ] Invoke `/zombuul:babysit test-pod "test extraction"` — verify CronCreate job created, first check runs
- [ ] Verify run-experiment skill renders with new babysit paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)