### PR TITLE
Add clone-count tracker and badge

### DIFF
--- a/.github/clone-count.json
+++ b/.github/clone-count.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "label": "clones",
+  "message": "0",
+  "color": "blue",
+  "total_clones": 0,
+  "total_uniques": 0,
+  "days": {}
+}

--- a/.github/update_clone_count.py
+++ b/.github/update_clone_count.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Merge the latest 14-day clones API response into a running total."""
+import json
+import sys
+from pathlib import Path
+
+new_data = json.loads(Path(sys.argv[1]).read_text())
+state_path = Path(sys.argv[2])
+
+if state_path.exists():
+    state = json.loads(state_path.read_text())
+    days = state["days"]
+    total = state["total_clones"]
+    uniques = state["total_uniques"]
+else:
+    days, total, uniques = {}, 0, 0
+
+for day in new_data["clones"]:
+    ts = day["timestamp"]
+    if ts in days:
+        prev = days[ts]
+    else:
+        prev = {"count": 0, "uniques": 0}
+    total += day["count"] - prev["count"]
+    uniques += day["uniques"] - prev["uniques"]
+    days[ts] = {"count": day["count"], "uniques": day["uniques"]}
+
+out = {
+    "schemaVersion": 1,
+    "label": "clones",
+    "message": str(total),
+    "color": "blue",
+    "total_clones": total,
+    "total_uniques": uniques,
+    "days": days,
+}
+
+state_path.write_text(json.dumps(out, indent=2) + "\n")

--- a/.github/workflows/clone-count.yml
+++ b/.github/workflows/clone-count.yml
@@ -1,0 +1,32 @@
+name: Update clone count
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch clone stats
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        run: gh api repos/${{ github.repository }}/traffic/clones > /tmp/clones.json
+
+      - name: Merge into running total
+        run: python3 .github/update_clone_count.py /tmp/clones.json .github/clone-count.json
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/clone-count.json
+          git diff --staged --quiet && exit 0
+          git commit -m "chore: update clone count [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zombuul
 
+![Clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ogilg/zombuul/main/.github/clone-count.json)
+
 Run AI safety experiments end-to-end, from spec to report. Claude Code handles the GPU pod, orchestration, and writeup. Locally, or fully remote.
 
 ## Install
@@ -64,4 +66,4 @@ You (local Claude Code)              Pod (RunPod GPU)
 
 Bugs, questions, feature ideas, or just want to share what you're running: all welcome. Open an [issue](https://github.com/ogilg/zombuul/issues) or start a [discussion](https://github.com/ogilg/zombuul/discussions). I read everything.
 
-Contact: `oscar.gilg18 [at] gmail [dot] com`
+Contact: `oscar.gilg18 [at] gmail [dot] com` / [@gilg_oscar](https://x.com/gilg_oscar) on X


### PR DESCRIPTION
## Summary
- Daily GitHub Action fetches `/traffic/clones`, merges into `.github/clone-count.json`, commits back
- README shows `clones: N` badge via shields.io endpoint API
- Also adds X handle (@gilg_oscar) to the Feedback section

## Setup before this runs
Requires a repo secret `TRAFFIC_TOKEN`:
1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens
2. Scope: `ogilg/zombuul` only
3. Permissions: **Administration: Read** (that's it — the default `GITHUB_TOKEN` can't access the traffic API)
4. Add as secret `TRAFFIC_TOKEN` at https://github.com/ogilg/zombuul/settings/secrets/actions

After merge, trigger the first run manually from the Actions tab (workflow_dispatch). Thereafter it runs daily at 04:00 UTC.

## Test plan
- [ ] `TRAFFIC_TOKEN` secret is set
- [ ] Manual workflow_dispatch run succeeds
- [ ] `.github/clone-count.json` is updated with real numbers
- [ ] Badge renders on the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)