### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/clone-count.yml
+++ b/.github/workflows/clone-count.yml
@@ -12,7 +12,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch clone stats
         env:


### PR DESCRIPTION
Silences the Node 20 deprecation warning in the clone-count workflow. v6 runs on Node 24.