### PR TITLE
Use PAT for clone-count commits

### DIFF
--- a/.github/workflows/clone-count.yml
+++ b/.github/workflows/clone-count.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PAT }}
 
       - name: Fetch clone stats
         env:


### PR DESCRIPTION
Fixes `GH006: Protected branch update failed` on main pushes. Mirrors the version-bump workflow which already uses `secrets.PAT` for the same reason.