### PR TITLE
Agents file zombuul issues autonomously

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Skills
 
 Skills are auto-discovered from `skills/`. Each skill is a directory with a `SKILL.md` file containing YAML frontmatter. No manual registration needed — just create the directory and file.
+
+## Agent-authored issues
+
+The main user-invocable skills (`run-experiment`, `babysit`, `launch-runpod`, `provision-pod`) instruct agents to file GitHub issues autonomously when they hit zombuul bugs/friction, even when running in someone else's repo. Issues land at https://github.com/ogilg/zombuul/issues. Expect a steady stream from live usage — treat them as field telemetry, and close/dedupe liberally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,4 @@ Skills are auto-discovered from `skills/`. Each skill is a directory with a `SKI
 
 ## Agent-authored issues
 
-The main user-invocable skills (`run-experiment`, `babysit`, `launch-runpod`, `provision-pod`) instruct agents to file GitHub issues autonomously when they hit zombuul bugs/friction, even when running in someone else's repo. Issues land at https://github.com/ogilg/zombuul/issues. Expect a steady stream from live usage — treat them as field telemetry, and close/dedupe liberally.
+The main user-invocable skills point agents at `REPORTING_BUGS.md`, which tells them to file GitHub issues autonomously when zombuul itself hits friction, even in someone else's repo. Expect a steady stream at https://github.com/ogilg/zombuul/issues — treat them as field telemetry, close/dedupe liberally.

--- a/REPORTING_BUGS.md
+++ b/REPORTING_BUGS.md
@@ -1,12 +1,12 @@
 # Reporting zombuul bugs (for agents)
 
-If during this session you hit friction in zombuul itself — failing pod setup, broken defaults, SSH/env quirks, silent crashes of zombuul scripts or skills, misleading error messages, missing features, monitoring gaps — file an issue before the session ends. **Do this even if you're running in someone else's repo** — the issue goes to the plugin, not the user's project.
+If during this session anything went wrong that zombuul could plausibly have done better, file an issue before the session ends. **Do this even if you're running in someone else's repo** — the issue goes to the plugin, not the user's project. Err on the side of filing: a duplicate or a "maybe not a bug" is cheap to triage; silent papercuts that keep costing users time are not.
 
 ## Scope
 
-**In scope (file an issue):** `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls (`pod_setup.sh`, `launch_on_pod.sh`), `runpod_ctl.py`, babysit/monitor behavior, and documented workflows that don't work as documented.
+**In scope:** anything zombuul controls or could reasonably control — `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup (`pod_setup.sh`, `launch_on_pod.sh`), `runpod_ctl.py`, babysit/monitor behavior, documented workflows that don't work as documented. If you had to work around something zombuul handed you, that's in scope.
 
-**Out of scope (do not file):** bugs in the user's experiment code, missing deps the user's project expects, model-specific issues, one-off RunPod outages, anything specific to the user's own setup or environment.
+**Out of scope:** bugs in the user's experiment code, missing deps specific to their project, one-off RunPod platform outages, anything specific to the user's personal setup.
 
 ## How
 
@@ -16,10 +16,11 @@ gh issue create --repo ogilg/zombuul \
   --body "<what happened + concrete command/error + suggested fix if obvious>"
 ```
 
-Include:
-- **What went wrong** (one or two sentences)
-- **Concrete example** — the exact command, the error, and the context (which skill was invoking it, what pod type, what model)
-- **Suggested fix** if obvious
+Document it well. At minimum:
+- **What went wrong** — one or two sentences, concretely.
+- **Reproduction** — the exact command(s), the error output, and the surrounding context (which skill was invoking it, what pod type, what model, what the user was trying to do). Include enough that someone who wasn't in the session could reproduce or at least understand.
+- **What would have helped** — a suggested fix if obvious, or the shape of a better behavior if not.
+- **Workaround used** (if any) — so other users hitting the same thing can unblock themselves before the fix lands.
 
 ## Conventions
 

--- a/REPORTING_BUGS.md
+++ b/REPORTING_BUGS.md
@@ -1,0 +1,29 @@
+# Reporting zombuul bugs (for agents)
+
+If during this session you hit friction in zombuul itself — failing pod setup, broken defaults, SSH/env quirks, silent crashes of zombuul scripts or skills, misleading error messages, missing features, monitoring gaps — file an issue before the session ends. **Do this even if you're running in someone else's repo** — the issue goes to the plugin, not the user's project.
+
+## Scope
+
+**In scope (file an issue):** `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls (`pod_setup.sh`, `launch_on_pod.sh`), `runpod_ctl.py`, babysit/monitor behavior, and documented workflows that don't work as documented.
+
+**Out of scope (do not file):** bugs in the user's experiment code, missing deps the user's project expects, model-specific issues, one-off RunPod outages, anything specific to the user's own setup or environment.
+
+## How
+
+```
+gh issue create --repo ogilg/zombuul \
+  --title "<short>" \
+  --body "<what happened + concrete command/error + suggested fix if obvious>"
+```
+
+Include:
+- **What went wrong** (one or two sentences)
+- **Concrete example** — the exact command, the error, and the context (which skill was invoking it, what pod type, what model)
+- **Suggested fix** if obvious
+
+## Conventions
+
+- Batch multiple small papercuts from one session into a single issue rather than filing five separate ones.
+- Before filing, skim recent open issues (`gh issue list --repo ogilg/zombuul --state open --limit 20`) and add a comment to an existing one instead of duplicating.
+- Tell the user in one line that you're filing so they can override ("Filing a zombuul issue about the `.env` parse error — let me know if you'd rather I skip it.").
+- Don't block on this — it's a reflection at session end or after hitting the bug, not during active work.

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -56,10 +56,6 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 
 5. **Report:** Show the cron job ID, what it's monitoring, and `CronDelete <id>` to cancel.
 
-## Report zombuul bugs autonomously
+## Report zombuul bugs
 
-If you detect a failure mode that zombuul itself could have prevented or handled better — a crash class the babysitter didn't catch, a silent hang with no output, a process killed by SIGHUP on SSH close, a disk/quota bug, a pod that kept billing after a job finished — file an issue. Do this even if running in someone else's repo.
-
-Scope is zombuul infrastructure only: `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls. Not the user's experiment code or deps.
-
-Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.
+If a crash class the babysitter didn't catch (silent hang, SIGHUP-on-disconnect, disk/quota, pod that kept billing) surfaced this session, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -58,4 +58,4 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 
 ## Report zombuul bugs
 
-If a crash class the babysitter didn't catch (silent hang, SIGHUP-on-disconnect, disk/quota, pod that kept billing) surfaced this session, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.
+If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -55,3 +55,11 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 4. **Run the first check immediately** — execute the same SSH process check inline so the user gets instant feedback. Don't wait for the first cron tick.
 
 5. **Report:** Show the cron job ID, what it's monitoring, and `CronDelete <id>` to cancel.
+
+## Report zombuul bugs autonomously
+
+If you detect a failure mode that zombuul itself could have prevented or handled better — a crash class the babysitter didn't catch, a silent hang with no output, a process killed by SIGHUP on SSH close, a disk/quota bug, a pod that kept billing after a job finished — file an issue. Do this even if running in someone else's repo.
+
+Scope is zombuul infrastructure only: `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls. Not the user's experiment code or deps.
+
+Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -54,4 +54,4 @@ Spin up a RunPod GPU pod interactively.
 
 ## Report zombuul bugs
 
-If pod creation or setup hit friction zombuul could have prevented (bad defaults, GPU fallback missing, broken `pod_setup.sh`, `.env` parse errors, missing tmux/venv), follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.
+If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -52,10 +52,6 @@ Spin up a RunPod GPU pod interactively.
    - If setup fails, don't debug individual steps — just re-run `pod_setup.sh`: `ssh runpod-<name> 'nohup bash /pod_setup.sh <repo_url> <branch> </dev/null > /var/log/pod_setup.log 2>&1 & disown'`. It's idempotent (skips clone if repo exists).
    - They can run `/zombuul:pause-runpod` to pause the pod when done (GPU billing stops, disk preserved).
 
-## Report zombuul bugs autonomously
+## Report zombuul bugs
 
-If pod creation or setup hits friction zombuul itself could have prevented — default disk/volume too small for the model, GPU type unavailable with no fallback, `pod_setup.sh` leaving the pod in a broken state, `.env` parse errors, missing `tmux` / `venv` papercuts — file an issue. Do this even in someone else's repo.
-
-Scope: zombuul infrastructure only (`${CLAUDE_PLUGIN_ROOT}/scripts/`, skills, `defaults.yaml`, pod setup the plugin controls). Not the user's code or deps.
-
-Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.
+If pod creation or setup hit friction zombuul could have prevented (bad defaults, GPU fallback missing, broken `pod_setup.sh`, `.env` parse errors, missing tmux/venv), follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -51,3 +51,11 @@ Spin up a RunPod GPU pod interactively.
    - The setup script is running in the background on the pod (clones repo, installs deps). Check `/var/log/pod_setup.log` on the pod for progress.
    - If setup fails, don't debug individual steps — just re-run `pod_setup.sh`: `ssh runpod-<name> 'nohup bash /pod_setup.sh <repo_url> <branch> </dev/null > /var/log/pod_setup.log 2>&1 & disown'`. It's idempotent (skips clone if repo exists).
    - They can run `/zombuul:pause-runpod` to pause the pod when done (GPU billing stops, disk preserved).
+
+## Report zombuul bugs autonomously
+
+If pod creation or setup hits friction zombuul itself could have prevented — default disk/volume too small for the model, GPU type unavailable with no fallback, `pod_setup.sh` leaving the pod in a broken state, `.env` parse errors, missing `tmux` / `venv` papercuts — file an issue. Do this even in someone else's repo.
+
+Scope: zombuul infrastructure only (`${CLAUDE_PLUGIN_ROOT}/scripts/`, skills, `defaults.yaml`, pod setup the plugin controls). Not the user's code or deps.
+
+Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -55,10 +55,6 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
    - What was synced (list .env, spec, data dirs as applicable)
    - Setup status (success or failure with instructions to check `/var/log/pod_setup.log`)
 
-## Report zombuul bugs autonomously
+## Report zombuul bugs
 
-If provisioning hits friction zombuul itself could have prevented — `wait-setup` reporting success when setup actually failed, `.env` sync that breaks on specific filename characters, rsync permission issues from the plugin defaults, missing SSH alias handling, duplicate alias entries piling up in `~/.ssh/config` — file an issue. Do this even in someone else's repo.
-
-Scope: zombuul infrastructure only (`${CLAUDE_PLUGIN_ROOT}/scripts/`, skills, `defaults.yaml`, pod setup the plugin controls). Not the user's code or deps.
-
-Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.
+If provisioning hit friction zombuul could have prevented (wait-setup false success, `.env` sync edge cases, SSH alias dupes, rsync perms), follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -54,3 +54,11 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
    - SSH command: `ssh runpod-<pod_name>`
    - What was synced (list .env, spec, data dirs as applicable)
    - Setup status (success or failure with instructions to check `/var/log/pod_setup.log`)
+
+## Report zombuul bugs autonomously
+
+If provisioning hits friction zombuul itself could have prevented — `wait-setup` reporting success when setup actually failed, `.env` sync that breaks on specific filename characters, rsync permission issues from the plugin defaults, missing SSH alias handling, duplicate alias entries piling up in `~/.ssh/config` — file an issue. Do this even in someone else's repo.
+
+Scope: zombuul infrastructure only (`${CLAUDE_PLUGIN_ROOT}/scripts/`, skills, `defaults.yaml`, pod setup the plugin controls). Not the user's code or deps.
+
+Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override.

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -57,4 +57,4 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
 
 ## Report zombuul bugs
 
-If provisioning hit friction zombuul could have prevented (wait-setup false success, `.env` sync edge cases, SSH alias dupes, rsync perms), follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.
+If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -253,10 +253,6 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 6. **Sync results** (local mode only, if a pod was used): sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
 7. **Commit and push.** Commit all outputs — reports, plots, scripts, data files (scores, configs, JSON results). Push: `git push -u origin HEAD`. Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing. (In on-pod mode you've already been pushing incrementally — this final push just tops it off.)
 
-## Report zombuul bugs autonomously
+## Report zombuul bugs
 
-If during this experiment you hit friction in zombuul itself — failing pod setup, broken defaults, SSH/env quirks, silent crashes of zombuul scripts or skills, misleading error messages, missing features — file an issue before the session ends. Do this even if you're running in someone else's repo; the issue goes to the plugin, not the user's project.
-
-Scope is zombuul infrastructure only: `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls. Do NOT file issues for bugs in the user's experiment code, their deps, or model-specific errors.
-
-Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override. Batch multiple small papercuts from one session into a single issue.
+If this session hit friction in zombuul itself, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -252,3 +252,11 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 5. **Review the report.** Launch a subagent (Agent tool, subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to `report.md`. Do not skip this step.
 6. **Sync results** (local mode only, if a pod was used): sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
 7. **Commit and push.** Commit all outputs — reports, plots, scripts, data files (scores, configs, JSON results). Push: `git push -u origin HEAD`. Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing. (In on-pod mode you've already been pushing incrementally — this final push just tops it off.)
+
+## Report zombuul bugs autonomously
+
+If during this experiment you hit friction in zombuul itself — failing pod setup, broken defaults, SSH/env quirks, silent crashes of zombuul scripts or skills, misleading error messages, missing features — file an issue before the session ends. Do this even if you're running in someone else's repo; the issue goes to the plugin, not the user's project.
+
+Scope is zombuul infrastructure only: `${CLAUDE_PLUGIN_ROOT}/scripts/`, the skills themselves, `defaults.yaml`, pod setup the plugin controls. Do NOT file issues for bugs in the user's experiment code, their deps, or model-specific errors.
+
+Command: `gh issue create --repo ogilg/zombuul --title "<short>" --body "<what happened + concrete command/error + suggested fix if obvious>"`. Tell the user in one line that you're filing so they can override. Batch multiple small papercuts from one session into a single issue.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -255,4 +255,4 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 
 ## Report zombuul bugs
 
-If this session hit friction in zombuul itself, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.
+If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.


### PR DESCRIPTION
## Summary

- Adds `REPORTING_BUGS.md` at plugin root — canonical instruction for agents to file GitHub issues against ogilg/zombuul when they hit plugin-level friction during a session.
- Instruments the four main user-invocable skills (`run-experiment`, `babysit`, `launch-runpod`, `provision-pod`) with a one-line pointer to `REPORTING_BUGS.md` and a context-specific nudge about what kinds of friction would qualify.
- Adds a note to the root `CLAUDE.md` framing the resulting issue stream as field telemetry.

## Motivation

Real-world zombuul sessions over the past week surfaced several papercuts (default disk too small for 122B models, `hf_xet`-on-MooseFS I/O errors, SSH-exit-255 noise, silent process death via nohup, babysit missing silent hangs, `.env` parse breaking on spaces, etc.) — four corresponding issues just landed (#56–#59). Rather than relying on the user to remember to file these post-hoc, instruct agents to file them directly, even when running in another user's repo. Scope is explicitly zombuul-infrastructure-only so the issue tracker doesn't fill with user-project bugs.

## Design notes

- One canonical doc, not duplicated across skills (second commit refactored this).
- Each skill's pointer names the categories of friction most likely encountered there, so agents don't need to scan `REPORTING_BUGS.md` just to decide whether to open it.
- Agents are told to announce the filing in one line so the user can override.
- Batching guidance + dedupe guidance included to keep the tracker clean.

## Test plan

- [ ] Next live zombuul session: verify agent actually files an issue on plugin-level friction (and doesn't file for user-project bugs).
- [ ] Confirm `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` resolves correctly from skill context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)