### PR TITLE
Spec-driven pod sizing; HF cache symlink; MooseFS docs (closes #56)

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -143,6 +143,11 @@ fi
 export UV_CACHE_DIR=/opt/uv_cache
 export HF_HOME=/opt/hf_cache
 mkdir -p /opt/uv_cache /opt/hf_cache
+# Belt-and-braces: redirect the default HF cache path to container disk too,
+# so tools that ignore HF_HOME still avoid the NFS/MooseFS volume.
+mkdir -p /root/.cache
+rm -rf /root/.cache/huggingface
+ln -sfn /opt/hf_cache /root/.cache/huggingface
 
 # --- Python environment ---
 

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -12,10 +12,12 @@ Spin up a RunPod GPU pod interactively.
 
 ## Arguments
 
-`$ARGUMENTS` is a whitespace-separated list: `[pod_name] [--remote]`.
+`$ARGUMENTS` is a whitespace-separated list: `[pod_name] [--remote] [--disk-gb N] [--volume-gb N]`.
 
 - `pod_name` (optional): short kebab-case pod name. Default `research`.
 - `--remote` (optional flag): if present, pass `--install-claude` to the create command. This installs Claude Code and the zombuul plugin on the pod so an agent can run *inside* the pod (used by `/zombuul:run-experiment <spec> --remote`). Omit for the default case where your local Claude drives the pod over SSH.
+- `--disk-gb N` (optional): container disk size (local NVMe; holds `/opt/hf_cache`, venv, checkpoints). Defaults from `~/.claude/zombuul.yaml` (currently 100). Callers that know what the pod will run (e.g. `/zombuul:run-experiment`) should set this explicitly based on spec needs; the default is only appropriate for small models.
+- `--volume-gb N` (optional): network volume size (MooseFS; for durable outputs that must persist across pauses). Defaults from config (currently 50). Note: MooseFS has a hidden per-user quota; `df` on `/workspace` reports the full pool but writes fail well before that — size conservatively and keep large downloads (HF cache) off the volume.
 
 ## Process
 
@@ -33,11 +35,12 @@ Spin up a RunPod GPU pod interactively.
 
 4. **Ask for docker image** if not obvious. Default comes from config (`~/.claude/zombuul.yaml` or shipped defaults). Only ask if the user might want a different image.
 
-5. **Create the pod** **in the background** (docker image, volume, and disk size default from config):
+5. **Create the pod** **in the background** (docker image defaults from config; disk/volume come from flags or config):
    - GPU: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <name> --gpu "<gpu_type_id>" --gpu-count <n>`
    - CPU: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <name> --cpu`
    - Add `--image "<image>"` only if the user specified a non-default image.
    - Add `--install-claude` if the caller passed `--remote` in `$ARGUMENTS`.
+   - Add `--disk-gb <N>` if the caller passed `--disk-gb` in `$ARGUMENTS`; same for `--volume-gb`. Omit both flags to fall back to config defaults.
    Use the pod name from $ARGUMENTS if provided, otherwise default to "research". The script auto-detects the repo URL and branch from the current working directory, creates the pod, waits for SSH, and SCPs `pod_setup.sh`. Claude Code credentials are only copied and installed when `--install-claude` is set.
 
 6. **Ask about provisioning**: After getting the pod ID, IP, and port from the create output, ask the user via AskUserQuestion:

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -55,6 +55,10 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
    - What was synced (list .env, spec, data dirs as applicable)
    - Setup status (success or failure with instructions to check `/var/log/pod_setup.log`)
 
+## Note on `/workspace` capacity
+
+The pod's `/workspace` lives on a MooseFS network volume with a hidden per-user quota. `df` reports the full pool (often tens of TB) but writes fail well before that. If an experiment needs to download large model weights, keep them off `/workspace` — `pod_setup.sh` already points `HF_HOME` at `/opt/hf_cache` on container disk for this reason. Flag to the user if the spec implies large writes to `/workspace`.
+
 ## Report zombuul bugs
 
 If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -70,7 +70,7 @@ When the subagent returns, show the user the spec path and summary. Ask: "Want m
 2. **Run the symlink commands** returned by the symlink discovery agent. Verify the experiment's input files are accessible.
 3. **Set up infrastructure** if GPU needed:
    - If the infrastructure agent found a running pod, use it.
-   - Otherwise: invoke `/zombuul:launch-runpod` (local mode — do NOT pass `remote`, the pod is just an SSH target). After it completes, sync experiment data via `/zombuul:provision-pod`, passing `data_dirs` explicitly (inferred from the spec) to skip interactive recon.
+   - Otherwise: **size the pod based on the spec before invoking launch-runpod.** See [Sizing a pod from the spec](#sizing-a-pod-from-the-spec) below. Then invoke `/zombuul:launch-runpod <pod_name> --disk-gb <N> --volume-gb <N>` (local mode — do NOT pass `--remote`, the pod is just an SSH target). After it completes, sync experiment data via `/zombuul:provision-pod`, passing `data_dirs` explicitly (inferred from the spec) to skip interactive recon.
    - Do NOT ask the user for GPU choice, data dirs, etc. Make reasonable choices. Only ask if truly blocked.
 
 Continue to [Execution model](#execution-model) and [Workflow](#workflow).
@@ -91,7 +91,7 @@ You are **not** running the experiment — you are setting up a pod that will ru
 
 ### R2: Pod setup
 
-1. **Reuse or create**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py list`. If a suitable pod is already running with claude installed (verify with `ssh runpod-<name> 'command -v claude'`), reuse it. Otherwise, invoke `/zombuul:launch-runpod <pod_name> --remote` — the `--remote` flag causes Claude Code + the zombuul plugin to be installed on the pod. Pick a distinctive 2-3 word kebab-case name based on the experiment.
+1. **Reuse or create**: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py list`. If a suitable pod is already running with claude installed (verify with `ssh runpod-<name> 'command -v claude'`), reuse it. Otherwise, **size the pod from the spec** (see [Sizing a pod from the spec](#sizing-a-pod-from-the-spec)) and invoke `/zombuul:launch-runpod <pod_name> --remote --disk-gb <N> --volume-gb <N>` — the `--remote` flag causes Claude Code + the zombuul plugin to be installed on the pod. Pick a distinctive 2-3 word kebab-case name based on the experiment.
 2. **Provision**: invoke `/zombuul:provision-pod` with `{"pod_id": ..., "pod_name": ..., "ip": ..., "port": ..., "spec_path": "<spec_path>", "data_dirs": [<from R1>]}`. Wait for completion. `provision-pod`'s `wait-setup` surfaces any setup failures — if it reports `claude binary not found`, re-run setup in remote mode via `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <same> ... --install-claude` (or re-invoke `/zombuul:launch-runpod <pod_name> --remote`).
 
 ### R3: Launch the on-pod agent
@@ -252,6 +252,33 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 5. **Review the report.** Launch a subagent (Agent tool, subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to `report.md`. Do not skip this step.
 6. **Sync results** (local mode only, if a pod was used): sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
 7. **Commit and push.** Commit all outputs — reports, plots, scripts, data files (scores, configs, JSON results). Push: `git push -u origin HEAD`. Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing. (In on-pod mode you've already been pushing incrementally — this final push just tops it off.)
+
+## Sizing a pod from the spec
+
+Before launching a new pod, derive `--disk-gb` and `--volume-gb` from what the spec is actually going to do. The config defaults (100 / 50) are only adequate for small models (≤13B). Do not rely on them for anything larger — undersized pods fail mid-run with ENOSPC or MooseFS quota errors that cost a full restart.
+
+**Container disk (`--disk-gb`)** — local NVMe on the pod. Holds `/opt/hf_cache` (HF weights), the Python venv, and any checkpoints/activations you generate during the run. Rough formula:
+
+```
+disk_gb ≈ model_params_in_B × 2.5    # bf16/fp16 weights + ~25% headroom
+        + 30                         # venv, tooling, logs
+        + expected_local_outputs_gb  # activations, checkpoints written locally
+```
+
+Concrete anchors: a 27B model → ~100 GB (default is fine). 70B → ~210 GB. 122B → ~355 GB — pass `--disk-gb 400` or higher. If the spec involves multiple models or iterative checkpointing, add their budgets.
+
+**Network volume (`--volume-gb`)** — MooseFS, persists across pauses, slower than NVMe, and has a hidden per-user quota (don't trust the "71 TB free" reported by `df`). Use only for durable outputs that must survive pod deletion. Size based on:
+
+```
+volume_gb ≈ expected_durable_artifacts_gb  # activations you rsync back, final checkpoints
+          + 20                             # headroom
+```
+
+Most experiments don't need more than the default 50. Bump it only when the spec explicitly writes large outputs to a gitignored path that needs to persist.
+
+**When in doubt, over-provision disk rather than volume** — container disk is cheap-per-GB-per-hour and the failure mode of undersizing it is catastrophic (full restart), whereas volume undersizing is recoverable by rsyncing off.
+
+Briefly note the chosen sizes and your reasoning in the running log so the user can critique them.
 
 ## Report zombuul bugs
 

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -255,30 +255,12 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 
 ## Sizing a pod from the spec
 
-Before launching a new pod, derive `--disk-gb` and `--volume-gb` from what the spec is actually going to do. The config defaults (100 / 50) are only adequate for small models (≤13B). Do not rely on them for anything larger — undersized pods fail mid-run with ENOSPC or MooseFS quota errors that cost a full restart.
+Defaults (100 GB disk / 50 GB volume) only fit small models (≤13B). Derive `--disk-gb` and `--volume-gb` from the spec before launching — undersized pods fail mid-run and cost a full restart.
 
-**Container disk (`--disk-gb`)** — local NVMe on the pod. Holds `/opt/hf_cache` (HF weights), the Python venv, and any checkpoints/activations you generate during the run. Rough formula:
+- **`--disk-gb`** (container NVMe; HF cache + venv + local outputs): `model_params_B × 2.5 + 30 + local_outputs_gb`. Anchors: 27B → 100, 70B → 210, 122B → 400. When unsure, round up.
+- **`--volume-gb`** (MooseFS; durable outputs that must survive pod deletion): default 50 is usually fine. Note: MooseFS has a hidden per-user quota; `df` reports the pool, not the limit.
 
-```
-disk_gb ≈ model_params_in_B × 2.5    # bf16/fp16 weights + ~25% headroom
-        + 30                         # venv, tooling, logs
-        + expected_local_outputs_gb  # activations, checkpoints written locally
-```
-
-Concrete anchors: a 27B model → ~100 GB (default is fine). 70B → ~210 GB. 122B → ~355 GB — pass `--disk-gb 400` or higher. If the spec involves multiple models or iterative checkpointing, add their budgets.
-
-**Network volume (`--volume-gb`)** — MooseFS, persists across pauses, slower than NVMe, and has a hidden per-user quota (don't trust the "71 TB free" reported by `df`). Use only for durable outputs that must survive pod deletion. Size based on:
-
-```
-volume_gb ≈ expected_durable_artifacts_gb  # activations you rsync back, final checkpoints
-          + 20                             # headroom
-```
-
-Most experiments don't need more than the default 50. Bump it only when the spec explicitly writes large outputs to a gitignored path that needs to persist.
-
-**When in doubt, over-provision disk rather than volume** — container disk is cheap-per-GB-per-hour and the failure mode of undersizing it is catastrophic (full restart), whereas volume undersizing is recoverable by rsyncing off.
-
-Briefly note the chosen sizes and your reasoning in the running log so the user can critique them.
+Note the chosen sizes in the running log.
 
 ## Report zombuul bugs
 


### PR DESCRIPTION
## Summary

- **`run-experiment` decides pod size from the spec, not heuristics.** New "Sizing a pod from the spec" section with rough formulae for container disk (HF weights + venv + local outputs) and volume (durable artifacts only). Concrete anchors: 27B → 100 GB, 70B → 210 GB, 122B → 400 GB.
- **`launch-runpod` accepts `--disk-gb` / `--volume-gb` passthrough** and forwards to `runpod_ctl.py create`. Config defaults still apply when callers don't pass flags — no hard-coded GPU-class branching.
- **`pod_setup.sh` adds a defensive symlink** `/root/.cache/huggingface -> /opt/hf_cache` so tools that ignore `HF_HOME` still land on container disk.
- **MooseFS quota note** added to `launch-runpod` and `provision-pod` skills so agents know `df` on `/workspace` reports the pool, not the quota.

## Design notes

Dropped the earlier GPU-class heuristic and the unconditional `hf_xet` guard. With `HF_HOME` on container disk by default, xet-on-MooseFS is moot for the happy path; callers deliberately overriding `HF_HOME` back to `/workspace` can set the env vars themselves. Leaving it out keeps the setup script simpler.

## Test plan

- [ ] Next experiment run for a >30B model: confirm agent reads spec, picks non-default `--disk-gb`, and pod has enough room for HF download.
- [ ] Confirm `--disk-gb` / `--volume-gb` pass through correctly to `runpod_ctl.py create` (already supported by the script).
- [ ] Verify `/root/.cache/huggingface` resolves to `/opt/hf_cache` on a fresh pod.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)