### PR TITLE
Fix provisioning papercuts (closes #57)

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -46,12 +46,21 @@ if [ -f /proc/1/environ ]; then
     export $(tr '\0' '\n' < /proc/1/environ | grep -E '^(HF_TOKEN|GH_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|RUNPOD_POD_ID)=')
 fi
 
-# Fallback: check for .env synced by provision-pod
+# Fallback: check for .env synced by provision-pod.
+# Use a read-loop with whitelist case match so values with spaces/quotes
+# don't break parsing (the old `export $(grep | xargs)` pattern did).
 for envfile in "$REPO_DIR/.env" /tmp/.env; do
     if [ -f "$envfile" ]; then
         echo "Found .env at $envfile — sourcing tokens."
-        # shellcheck disable=SC2046
-        export $(grep -E '^(GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY)=' "$envfile" | xargs)
+        while IFS='=' read -r key value; do
+            case "$key" in
+                GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY)
+                    value="${value%\"}"; value="${value#\"}"
+                    value="${value%\'}"; value="${value#\'}"
+                    export "$key=$value"
+                    ;;
+            esac
+        done < "$envfile"
         break
     fi
 done
@@ -61,13 +70,13 @@ done
 retry "apt-get update" 3 10 apt-get update
 
 install_system_packages() {
-    if command -v jq &>/dev/null && command -v rsync &>/dev/null; then
-        echo "jq and rsync already installed."
+    if command -v jq &>/dev/null && command -v rsync &>/dev/null && command -v tmux &>/dev/null; then
+        echo "jq, rsync, and tmux already installed."
         return 0
     fi
-    apt-get install -y jq rsync
+    apt-get install -y jq rsync tmux
 }
-retry "install jq+rsync" 3 10 install_system_packages
+retry "install jq+rsync+tmux" 3 10 install_system_packages
 
 # gh CLI (non-critical — used for PR operations but not essential)
 install_gh() {
@@ -161,6 +170,9 @@ fi
 # shellcheck disable=SC1091
 source /opt/venvs/research/bin/activate
 cd "$REPO_DIR" || exit 1
+# Discoverability: symlink $REPO_DIR/.venv → /opt/venvs/research so IDEs,
+# `uv`, and bare `.venv/bin/python` invocations find the research venv.
+ln -sfn /opt/venvs/research "$REPO_DIR/.venv"
 # Install project dependencies.
 # Supports pyproject.toml (with optional extras), requirements.txt, or setup.py.
 # Skips install if none are found.
@@ -248,3 +260,5 @@ if [ ${#SETUP_FAILURES[@]} -gt 0 ]; then
 else
     echo "=== Setup complete ==="
 fi
+echo "Research venv: /opt/venvs/research/bin/python (also symlinked at $REPO_DIR/.venv)"
+echo "HF cache: /opt/hf_cache  UV cache: /opt/uv_cache"

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -290,6 +290,16 @@ def pause_pod(pod_id: str):
     print("Pod paused. Disk is preserved; GPU billing stopped.")
 
 
+def terminate_pod(pod_id: str, yes: bool = False):
+    if not yes:
+        print(f"ERROR: `terminate` destroys pod {pod_id} and all its disk contents.")
+        print("Pass --yes to confirm.")
+        sys.exit(2)
+    print(f"Terminating pod {pod_id}...")
+    runpod.terminate_pod(pod_id)
+    print("Pod terminated. Disk destroyed; all billing stopped.")
+
+
 def resume_pod(pod_id: str, gpu_count: int = 1):
     print(f"Resuming pod {pod_id} with gpu_count={gpu_count}...")
     if gpu_count == 0:
@@ -393,6 +403,10 @@ def main():
     pause = sub.add_parser("pause", help="Pause a pod (stop GPU billing, keep disk)")
     pause.add_argument("pod_id")
 
+    terminate = sub.add_parser("terminate", help="Destroy a pod (stops billing, deletes disk). Requires --yes.")
+    terminate.add_argument("pod_id")
+    terminate.add_argument("--yes", action="store_true", help="Confirm destruction (disk is deleted).")
+
     resume = sub.add_parser("resume", help="Resume a paused pod")
     resume.add_argument("pod_id")
     resume.add_argument("--gpu-count", type=int, default=1, help="Number of GPUs to resume with (default: 1). Passing 0 is accepted by the RunPod API but does not actually boot GPU-reserved pods — see `resume_pod` docstring.")
@@ -431,6 +445,8 @@ def main():
         )
     elif args.command == "pause":
         pause_pod(args.pod_id)
+    elif args.command == "terminate":
+        terminate_pod(args.pod_id, yes=args.yes)
     elif args.command == "resume":
         resume_pod(args.pod_id, gpu_count=args.gpu_count)
     elif args.command == "status":


### PR DESCRIPTION
## Summary

Four small fixes, all in `pod_setup.sh` and `runpod_ctl.py`:

- **tmux** now installed alongside `jq`/`rsync` — every fresh pod was hitting `tmux: command not found`.
- **Venv discoverability**: `$REPO_DIR/.venv` symlinks to `/opt/venvs/research`, and the setup summary prints the venv path. IDEs, `uv`, and bare `.venv/bin/python` all work without trial-and-error.
- **`.env` parsing**: replaced `export \$(grep | xargs)` with a whitelist read-loop. Old version broke on values with spaces (`OWNER="Oscar Gilg"` → `.env: line 25: Gilg: command not found`). New version strips surrounding quotes and tolerates spaces; still whitelist-bounded.
- **`runpod_ctl.py terminate`**: new subcommand, gated behind `--yes`. Escape hatch when a pod is stuck on a bad network volume and `pause` isn't enough.

## Test plan

- [ ] Fresh pod launch: confirm `tmux` available, `.venv/bin/python` works, setup summary names the venv path.
- [ ] `.env` with a quoted value containing a space sources cleanly.
- [ ] `runpod_ctl.py terminate <id>` without `--yes` errors; with `--yes` destroys the pod.

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)