### PR TITLE
tmux over nohup + simplify pass (closes #58)

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -47,12 +47,10 @@ if [ -f /proc/1/environ ]; then
 fi
 
 # Fallback: check for .env synced by provision-pod.
-# Use a read-loop with whitelist case match so values with spaces/quotes
-# don't break parsing (the old `export $(grep | xargs)` pattern did).
 for envfile in "$REPO_DIR/.env" /tmp/.env; do
     if [ -f "$envfile" ]; then
         echo "Found .env at $envfile — sourcing tokens."
-        while IFS='=' read -r key value; do
+        while IFS='=' read -r key value || [ -n "$key" ]; do
             case "$key" in
                 GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY)
                     value="${value%\"}"; value="${value#\"}"
@@ -152,11 +150,11 @@ fi
 export UV_CACHE_DIR=/opt/uv_cache
 export HF_HOME=/opt/hf_cache
 mkdir -p /opt/uv_cache /opt/hf_cache
-# Belt-and-braces: redirect the default HF cache path to container disk too,
-# so tools that ignore HF_HOME still avoid the NFS/MooseFS volume.
 mkdir -p /root/.cache
-rm -rf /root/.cache/huggingface
-ln -sfn /opt/hf_cache /root/.cache/huggingface
+# Only replace /root/.cache/huggingface if missing or a symlink; never rm a real cache dir.
+if [ -L /root/.cache/huggingface ] || [ ! -e /root/.cache/huggingface ]; then
+    ln -sfn /opt/hf_cache /root/.cache/huggingface
+fi
 
 # --- Python environment ---
 
@@ -170,9 +168,13 @@ fi
 # shellcheck disable=SC1091
 source /opt/venvs/research/bin/activate
 cd "$REPO_DIR" || exit 1
-# Discoverability: symlink $REPO_DIR/.venv → /opt/venvs/research so IDEs,
-# `uv`, and bare `.venv/bin/python` invocations find the research venv.
-ln -sfn /opt/venvs/research "$REPO_DIR/.venv"
+# Replace any existing .venv first: ln -sfn into an existing dir nests the symlink inside it.
+if [ -L "$REPO_DIR/.venv" ] || [ ! -e "$REPO_DIR/.venv" ]; then
+    ln -sfn /opt/venvs/research "$REPO_DIR/.venv"
+else
+    rm -rf "$REPO_DIR/.venv"
+    ln -sfn /opt/venvs/research "$REPO_DIR/.venv"
+fi
 # Install project dependencies.
 # Supports pyproject.toml (with optional extras), requirements.txt, or setup.py.
 # Skips install if none are found.

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -18,11 +18,11 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 
 1. **Parse arguments.** Split into pod_name and description. If either is empty, show usage and stop.
 
-2. **Snapshot the running command.** SSH to the pod and capture what's running:
+2. **Snapshot the running command and its tmux session.** SSH to the pod and capture both:
    ```
-   ssh runpod-<pod_name> 'ps aux | grep python | grep -v grep'
+   ssh runpod-<pod_name> 'tmux list-sessions 2>/dev/null; ps aux | grep python | grep -v grep'
    ```
-   Save this output — it goes into the cron prompt so the babysitter agent knows what to restart.
+   Save this output — it goes into the cron prompt so the babysitter agent knows the session name and exact command to restart. If the job was launched without tmux (legacy), fall back to the `ps` output alone.
 
 3. **Create the cron job.** Use `CronCreate` with cron `*/5 * * * *` (every 5 min), recurring: true. The prompt must be **completely self-contained** — the cron agent has no conversation history. Build it from this template:
 
@@ -34,7 +34,7 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 
    ## Check
 
-   1. `ssh runpod-{pod_name} 'ps aux | grep python | grep -v grep'`
+   1. Liveness: `ssh runpod-{pod_name} 'tmux has-session -t <session> 2>/dev/null && echo alive || echo dead'`. If the job was launched without tmux, fall back to `ps aux | grep python | grep -v grep`.
 
    2. **If alive:** Check progress from the description (count output files, tail logs, etc.). Report one line: "{N}/{total} done" or similar.
 
@@ -42,7 +42,7 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
       a. Check logs: `ssh runpod-{pod_name} 'tail -30 /workspace/repo/<likely_log_path>'`
       b. Diagnose (OOM? I/O error? completed successfully?).
       c. If completed successfully → go to step 4.
-      d. If crashed → restart using the last known command above (adjust working dir, log path as needed). Report what happened.
+      d. If crashed → restart using the last known command above inside a new tmux session (`tmux new-session -d -s <session> '<cmd>'`). Report what happened.
 
    4. **If done** (all expected outputs exist per the description):
       a. Report completion.

--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -22,7 +22,7 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
    ```
    ssh runpod-<pod_name> 'tmux list-sessions 2>/dev/null; ps aux | grep python | grep -v grep'
    ```
-   Save this output — it goes into the cron prompt so the babysitter agent knows the session name and exact command to restart. If the job was launched without tmux (legacy), fall back to the `ps` output alone.
+   Save this output — it goes into the cron prompt so the babysitter agent knows the session name and exact command to restart.
 
 3. **Create the cron job.** Use `CronCreate` with cron `*/5 * * * *` (every 5 min), recurring: true. The prompt must be **completely self-contained** — the cron agent has no conversation history. Build it from this template:
 

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -16,8 +16,8 @@ Spin up a RunPod GPU pod interactively.
 
 - `pod_name` (optional): short kebab-case pod name. Default `research`.
 - `--remote` (optional flag): if present, pass `--install-claude` to the create command. This installs Claude Code and the zombuul plugin on the pod so an agent can run *inside* the pod (used by `/zombuul:run-experiment <spec> --remote`). Omit for the default case where your local Claude drives the pod over SSH.
-- `--disk-gb N` (optional): container disk size (local NVMe; holds `/opt/hf_cache`, venv, checkpoints). Defaults from `~/.claude/zombuul.yaml` (currently 100). Callers that know what the pod will run (e.g. `/zombuul:run-experiment`) should set this explicitly based on spec needs; the default is only appropriate for small models.
-- `--volume-gb N` (optional): network volume size (MooseFS; for durable outputs that must persist across pauses). Defaults from config (currently 50). Note: MooseFS has a hidden per-user quota; `df` on `/workspace` reports the full pool but writes fail well before that — size conservatively and keep large downloads (HF cache) off the volume.
+- `--disk-gb N` (optional): container disk (local NVMe; HF cache, venv, checkpoints). Default 100 from config; size up for larger models.
+- `--volume-gb N` (optional): network volume (MooseFS; durable outputs). Default 50 from config.
 
 ## Process
 

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -99,9 +99,9 @@ You are **not** running the experiment — you are setting up a pod that will ru
 Execute all three steps without pausing to confirm — this is the whole point of remote mode.
 
 1. **Copy the launch script to the pod**: `scp ${CLAUDE_PLUGIN_ROOT}/scripts/launch_on_pod.sh runpod-<name>:/tmp/launch_on_pod.sh`
-2. **Launch under nohup + disown** with branch and spec path as positional args:
-   `ssh runpod-<name> 'chmod +x /tmp/launch_on_pod.sh && nohup /tmp/launch_on_pod.sh <branch> <spec_path> </dev/null > /workspace/launch.log 2>&1 & disown'`
-3. **Verify the claude process is running**: `ssh runpod-<name> 'ps aux | grep claude | grep -v grep'`.
+2. **Launch inside a named tmux session** (survives SSH drops cleanly; `nohup ... & disown` gets killed by SIGHUP in some drop scenarios):
+   `ssh runpod-<name> "chmod +x /tmp/launch_on_pod.sh && tmux new-session -d -s zombuul '/tmp/launch_on_pod.sh <branch> <spec_path> > /workspace/launch.log 2>&1'"`
+3. **Verify the session is running**: `ssh runpod-<name> 'tmux has-session -t zombuul && echo alive'`. Re-attach live with `ssh runpod-<name> -t 'tmux attach -t zombuul'`.
 
 The script sources `~/.bash_profile` (for tokens), registers a `trap pause_pod EXIT` so the pod auto-pauses on any agent exit including crashes, then runs `claude -p '/zombuul:run-experiment <spec>'` with `IS_SANDBOX=1`. See `scripts/launch_on_pod.sh` for the full script.
 
@@ -162,11 +162,11 @@ Keep commits small and labeled (`log: <step>`, `result: <step>`, `fix: <what>`).
 - While waiting: prepare next steps, write analysis code, set up plotting scripts.
 
 **Babysitting long GPU jobs (local mode only):**
-For GPU jobs expected to take more than ~10 minutes, use nohup + babysit instead of `run_in_background`. This handles crash recovery automatically.
+For GPU jobs expected to take more than ~10 minutes, launch inside tmux + invoke babysit instead of using `run_in_background`. tmux sessions survive SSH drops; babysit handles crash recovery.
 
-1. Launch the job so it survives SSH disconnect:
-   `ssh runpod-<name> 'cd /workspace/repo && nohup python -u -m <module> > <log_path> 2>&1 & disown'`
-2. Invoke `/zombuul:babysit <pod_name> <description>` — this sets up a cron job that checks every 5 min, restarts on crash, and pauses the pod when done.
+1. Launch the job in a named tmux session (pick `<session>` to match the job, e.g. `extraction`):
+   `ssh runpod-<name> "tmux new-session -d -s <session> 'cd /workspace/repo && python -u -m <module> > <log_path> 2>&1'"`
+2. Invoke `/zombuul:babysit <pod_name> <description>` — this sets up a cron job that checks every 5 min, restarts on crash, and pauses the pod when done. Include the tmux session name in the description so babysit can check liveness via `tmux has-session`.
 3. You are free to work on other tasks while the babysitter monitors. It will report progress and any issues to the conversation.
 
 **Audit on launch:**

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -99,9 +99,9 @@ You are **not** running the experiment — you are setting up a pod that will ru
 Execute all three steps without pausing to confirm — this is the whole point of remote mode.
 
 1. **Copy the launch script to the pod**: `scp ${CLAUDE_PLUGIN_ROOT}/scripts/launch_on_pod.sh runpod-<name>:/tmp/launch_on_pod.sh`
-2. **Launch inside a named tmux session** (survives SSH drops cleanly; `nohup ... & disown` gets killed by SIGHUP in some drop scenarios):
-   `ssh runpod-<name> "chmod +x /tmp/launch_on_pod.sh && tmux new-session -d -s zombuul '/tmp/launch_on_pod.sh <branch> <spec_path> > /workspace/launch.log 2>&1'"`
-3. **Verify the session is running**: `ssh runpod-<name> 'tmux has-session -t zombuul && echo alive'`. Re-attach live with `ssh runpod-<name> -t 'tmux attach -t zombuul'`.
+2. **Launch inside a named tmux session** (survives SSH drops; nohup+disown dies on SIGHUP). The session name must be unique per concurrent job — use `zombuul-<name>`:
+   `ssh runpod-<name> "chmod +x /tmp/launch_on_pod.sh && tmux new-session -d -s zombuul-<name> '/tmp/launch_on_pod.sh <branch> <spec_path> > /workspace/launch.log 2>&1'"`
+3. **Verify the session is running**: `ssh runpod-<name> 'tmux has-session -t zombuul-<name> && echo alive'`. Re-attach live with `ssh runpod-<name> -t 'tmux attach -t zombuul-<name>'`.
 
 The script sources `~/.bash_profile` (for tokens), registers a `trap pause_pod EXIT` so the pod auto-pauses on any agent exit including crashes, then runs `claude -p '/zombuul:run-experiment <spec>'` with `IS_SANDBOX=1`. See `scripts/launch_on_pod.sh` for the full script.
 
@@ -255,10 +255,10 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 
 ## Sizing a pod from the spec
 
-Defaults (100 GB disk / 50 GB volume) only fit small models (≤13B). Derive `--disk-gb` and `--volume-gb` from the spec before launching — undersized pods fail mid-run and cost a full restart.
+Defaults (100 GB disk / 50 GB volume) only fit small models. Derive `--disk-gb` and `--volume-gb` from the spec before launching — undersized pods fail mid-run and cost a full restart.
 
-- **`--disk-gb`** (container NVMe; HF cache + venv + local outputs): `model_params_B × 2.5 + 30 + local_outputs_gb`. Anchors: 27B → 100, 70B → 210, 122B → 400. When unsure, round up.
-- **`--volume-gb`** (MooseFS; durable outputs that must survive pod deletion): default 50 is usually fine. Note: MooseFS has a hidden per-user quota; `df` reports the pool, not the limit.
+- **`--disk-gb`** (container NVMe; HF cache + venv + local outputs): `model_params_B × 2.5 + 30 + local_outputs_gb`. Round up.
+- **`--volume-gb`** (MooseFS; durable outputs only): default 50 is usually fine.
 
 Note the chosen sizes in the running log.
 


### PR DESCRIPTION
## Summary

Two logical changes:

**(1) Launch long jobs in tmux, not nohup+disown (closes #58).**
The only confirmed sub-point of #58 is processes vanishing silently via SIGHUP on SSH drop (incident e081 last week — extraction disappeared mid-download, had to manually switch to tmux). Other #58 sub-points (silent hang, disk watchdog, stuck CPU) haven't actually bitten us and are deferred. Swap:

- \`run-experiment\` R3 and local-mode babysit workflow use \`tmux new-session -d -s <name> '<cmd>'\` instead of \`nohup ... & disown\`.
- \`babysit\` liveness check uses \`tmux has-session -t <session>\` instead of \`ps | grep python\`. Snapshot captures both \`tmux list-sessions\` and \`ps\` so the restart command is preserved.

**(2) Simplify pass on recent work** (this branch + the three merged PRs: #60, #61, #62).

Bug fixes caught by review:
- tmux session name parameterized (\`zombuul-<pod_name>\`) so concurrent jobs on one pod don't collide silently.
- \`.env\` read-loop handles files without trailing newlines.
- HF cache symlink guarded — never \`rm -rf\`'s a real cache directory on setup re-run.
- \`.venv\` symlink guarded against an existing directory (prevents \`ln -sfn\` from nesting the symlink inside).

Parsimony:
- Dropped leaky "why old code failed" comments from \`pod_setup.sh\`.
- Dropped concrete model-size anchors from the sizing section (formula stands alone).
- MooseFS quota warning consolidated to \`provision-pod\` only (was in three skills).
- Tightened launch-runpod disk/volume bullets and babysit snapshot prose.

## Test plan

- [ ] Two concurrent \`/run-experiment --remote\` against the same pod: both tmux sessions live, neither clobbers the other.
- [ ] Setup re-run on a pod where \`.venv\` or \`/root/.cache/huggingface\` already exist: no data loss, symlinks correct.
- [ ] \`.env\` without trailing newline sources all tokens correctly.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)