### PR TITLE
Fix pause-semantics messaging: only /workspace survives pause

### DIFF
--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -287,7 +287,10 @@ def list_pods():
 def pause_pod(pod_id: str):
     print(f"Pausing pod {pod_id}...")
     runpod.stop_pod(pod_id)
-    print("Pod paused. Disk is preserved; GPU billing stopped.")
+    print("Pod paused. GPU billing stopped.")
+    print("Note: /workspace volume preserved; container disk (/, /opt/, /root/) is WIPED on resume.")
+    print("If important experiment data lives on container disk, rsync it off-pod or to /workspace/ before pausing.")
+    print("(Persistence is best-effort, not a guarantee — /workspace/ has its own pathologies.)")
 
 
 def terminate_pod(pod_id: str, yes: bool = False):

--- a/skills/launch-runpod/SKILL.md
+++ b/skills/launch-runpod/SKILL.md
@@ -16,8 +16,8 @@ Spin up a RunPod GPU pod interactively.
 
 - `pod_name` (optional): short kebab-case pod name. Default `research`.
 - `--remote` (optional flag): if present, pass `--install-claude` to the create command. This installs Claude Code and the zombuul plugin on the pod so an agent can run *inside* the pod (used by `/zombuul:run-experiment <spec> --remote`). Omit for the default case where your local Claude drives the pod over SSH.
-- `--disk-gb N` (optional): container disk (local NVMe; HF cache, venv, checkpoints). Default 100 from config; size up for larger models.
-- `--volume-gb N` (optional): network volume (MooseFS; durable outputs). Default 50 from config.
+- `--disk-gb N` (optional): container disk (local NVMe; HF cache, venv, regenerable intermediates). **WIPED on pause/resume** — do not store persistent experiment outputs here. Default 100 from config; size up for larger models.
+- `--volume-gb N` (optional): network volume (MooseFS; durable outputs that survive pause). Default 50 from config. Has a hidden per-user quota — keep small unless the experiment specifically needs it.
 
 ## Process
 

--- a/skills/pause-runpod/SKILL.md
+++ b/skills/pause-runpod/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: zombuul:pause-runpod
-description: Pause a RunPod pod (stop GPU billing, keep disk).
+description: "Pause a RunPod pod: stop GPU billing; keep /workspace only (container disk is wiped on resume)."
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---
 
-Pause a running RunPod pod without terminating it. The disk is preserved and GPU billing stops.
+Pause a running RunPod pod without terminating it. Only the `/workspace` MooseFS volume is preserved across pause — container disk (`/`, `/opt/`, `/root/`) is wiped on resume.
 
 ## Process
 
@@ -13,6 +13,8 @@ Pause a running RunPod pod without terminating it. The disk is preserved and GPU
 
 2. If there are multiple pods, **ask the user** which one to pause using AskUserQuestion.
 
-3. **Pause**: Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>`.
+3. **Remind the user about data loss risk.** Before pausing, note in the chat that pausing wipes container disk (`/`, `/opt/`, `/root/`) and only `/workspace/` survives. Suggest they rsync important experiment outputs off-pod or to `/workspace/` first. This is a reminder, not a hard block — continue to the pause command.
 
-4. If no pods are running, tell the user.
+4. **Pause**: Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>`.
+
+5. If no pods are running, tell the user.

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -59,6 +59,8 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
 
 The pod's `/workspace` lives on a MooseFS network volume with a hidden per-user quota. `df` reports the full pool (often tens of TB) but writes fail well before that. If an experiment needs to download large model weights, keep them off `/workspace` — `pod_setup.sh` already points `HF_HOME` at `/opt/hf_cache` on container disk for this reason. Flag to the user if the spec implies large writes to `/workspace`.
 
+Flip side: pause preserves `/workspace/` but wipes container disk. The two filesystems have opposite tradeoffs — experiment outputs that must survive pause belong on `/workspace/`; caches and venvs belong on container disk.
+
 ## Report zombuul bugs
 
 If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -257,8 +257,17 @@ Scannable — someone should grasp the full arc in 30 seconds. Headlines over pr
 
 Defaults (100 GB disk / 50 GB volume) only fit small models. Derive `--disk-gb` and `--volume-gb` from the spec before launching — undersized pods fail mid-run and cost a full restart.
 
-- **`--disk-gb`** (container NVMe; HF cache + venv + local outputs): `model_params_B × 2.5 + 30 + local_outputs_gb`. Round up.
-- **`--volume-gb`** (MooseFS; durable outputs only): default 50 is usually fine.
+**Persistence semantics (read first):** the two filesystems have opposite tradeoffs.
+
+- **Container disk** (`/`, `/opt/`, `/root/`) is fast local NVMe, no quota — but **wiped on pause/resume**. Use for HF cache, venv, regenerable intermediates.
+- **`/workspace/`** is a MooseFS network volume — durable across pause but has a hidden per-user quota (writes start failing around ~90 GB observed) and transient I/O errors on large-concurrent-write patterns (e.g. HuggingFace xet). Use for the cloned repo, logs, and experiment outputs that must survive pause.
+
+The default posture: HF cache + venv on container disk; experiment outputs directly on `/workspace/`. If outputs are both large (>50 GB) and need to survive pause, rsync off-pod rather than relying on `/workspace/`.
+
+**Typical sizing:**
+
+- **`--disk-gb`** (container): `model_params_B × 2.5 + 30 + temp_intermediates_gb`. Round up. Anchors: 27B → 100, 70B → 210, 122B → 500.
+- **`--volume-gb`** (workspace): default 50 is usually fine. Keep it small to avoid approaching quota — anything bigger is a signal you should probably rsync off-pod instead.
 
 Note the chosen sizes in the running log.
 


### PR DESCRIPTION
## Summary

`pause_pod` was printing `Disk is preserved` — but only the `/workspace` MooseFS volume actually survives pause/resume. The container disk (`/`, `/opt/`, `/root/`) is wiped. Combined with zombuul's other guidance steering bulk outputs onto container disk (via `--disk-gb` sizing in #61 + HF cache symlink in `pod_setup.sh`), this was easy to misread as "safe to pause any time". It cost a completed 7-persona Qwen-3.5-122B activation extraction this week.

## Changes

Five files, all doc or print-statement edits — no behavior changes:

- **`scripts/runpod_ctl.py::pause_pod`**: four-line truthful message (`/workspace` preserved, container disk wiped, rsync first, best-effort).
- **`skills/pause-runpod/SKILL.md`**: description fixed; new process step 3 reminds the user about data loss risk before the pause command runs.
- **`skills/launch-runpod/SKILL.md`**: `--disk-gb` bullet replaces misleading "checkpoints" wording with "regenerable intermediates — WIPED on pause". `--volume-gb` gains a quota caveat.
- **`skills/run-experiment/SKILL.md`** "Sizing a pod" section: gains a "Persistence semantics (read first)" paragraph explaining the two filesystems' opposite tradeoffs, with sizing anchors.
- **`skills/provision-pod/SKILL.md`**: `/workspace` capacity note gains a flip-side sentence tying quota awareness to the pause/persistence split.

## Supersedes

Partially supersedes #63 ("experiment outputs → container disk"). That was one workaround for MooseFS flakiness, but for most experiments direct writes to `/workspace/` at modest volumes (< 10 GB, not HF-cache-scale) are fine and avoid the pause wipe entirely. Clearer messaging + spec-driven sizing is the simpler fix. Will close #63.

## Test plan

- [ ] After merge, `/reload-plugins` and confirm the new version in `~/.claude/plugins/cache/ogilg-marketplace/zombuul/<new>/`.
- [ ] `python ~/.claude/plugins/cache/.../runpod_ctl.py pause <paused pod id>` prints the 4-line message.
- [ ] Invoke `/zombuul:pause-runpod` interactively — confirm the agent prints the reminder text before running the pause command.
- [ ] Skim the three other SKILL.md diffs; confirm no broken markdown or dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)