### PR TITLE
ci: simplify review only runs when ogilg triggers

### DIFF
--- a/.github/workflows/simplify.yml
+++ b/.github/workflows/simplify.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   review:
+    if: github.actor == 'ogilg'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Gates the simplify review job on `github.actor == 'ogilg'` for public-repo safety. PRs from anyone else (future collaborators, bots, etc.) won't trigger the action and won't expose the OAuth token to potentially-untrusted PR content.

## Test plan
- [ ] Self-test on this PR — actor is ogilg, so the workflow should still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)