### PR TITLE
ci: allow tools needed for simplify review to act

### DIFF
--- a/.github/workflows/simplify.yml
+++ b/.github/workflows/simplify.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: anthropics/claude-code-action@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Read,Glob,Grep,Bash,Edit,Write,mcp__github_inline_comment__create_inline_comment,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review
           prompt: |
             Review this PR aggressively for reuse, quality, and efficiency. Deliver concrete improvements — don't just list concerns.
 


### PR DESCRIPTION
## Summary
- Adds `--allowedTools` via `claude_args` so Claude can push commits and post inline comments. Same fix already applied to corroborate; without it Claude hits permission denials and produces nothing.

## Test plan
- [ ] Self-test fails (workflow modification skip), but next non-workflow PR will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)