### PR TITLE
Split finalize-experiment + babysit --on-complete

### DIFF
--- a/skills/babysit/SKILL.md
+++ b/skills/babysit/SKILL.md
@@ -1,22 +1,31 @@
 ---
 name: zombuul:babysit
 description: >
-  Monitor a long-running job on a RunPod GPU pod. Checks every 5 min, restarts on crash, pauses pod when done.
-  Argument $ARGUMENTS — `<pod_name> <description of what's running>`.
+  Monitor a long-running job on a RunPod GPU pod. Checks every 5 min, restarts on crash, and either
+  pauses the pod or fires a follow-up prompt when done.
+  Argument $ARGUMENTS — `<pod_name> <description> [--on-complete "<prompt>"]`.
   Use when a GPU job is expected to take >10 min and may crash (I/O errors, OOM, SSH timeouts).
-  The description should say what's running and how to tell when it's done (e.g., "E1c extraction — 121 conditions in activations/qwen35_122b_ood/e1c/").
+  The description should say what's running and how to tell when it's done. Pass `--on-complete`
+  to chain the next step (e.g. `/zombuul:finalize-experiment <spec> --pod <name>`) so the workflow
+  resumes automatically when the job finishes.
 user-invocable: true
 ---
 
-Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning up when done.
+Monitor a long-running GPU job on a RunPod pod, restarting on crash and either pausing the pod or handing off to a follow-up step when the job finishes.
 
 ## Arguments
 
-`$ARGUMENTS` is `<pod_name> <description>`. The first whitespace-delimited token is the pod name (must match an SSH alias `runpod-<pod_name>`). Everything after it is a natural-language description of what's running and how to tell when it's done.
+`$ARGUMENTS` is `<pod_name> <description> [--on-complete "<prompt>"]`.
+
+- `<pod_name>` (first whitespace-delimited token, required) — must match an SSH alias `runpod-<pod_name>`.
+- `<description>` (required) — natural-language description of what's running and how to tell when it's done. Used as the body of the cron's progress reporting.
+- `--on-complete "<prompt>"` (optional) — a self-contained prompt to fire when the job finishes cleanly. Most often `/zombuul:finalize-experiment <spec_path> --pod <pod_name>`. When set, babysit does NOT pause the pod itself — the on-complete prompt is responsible for syncing results, pausing, etc. When not set, babysit pauses the pod itself on completion.
+
+To parse: `--on-complete` is followed by a quoted string. Everything between the quotes after `--on-complete` is the on-complete prompt; everything before `--on-complete` (after the pod name) is the description.
 
 ## Process
 
-1. **Parse arguments.** Split into pod_name and description. If either is empty, show usage and stop.
+1. **Parse arguments.** Split out `pod_name`, `description`, and optional `on_complete`. If pod_name or description is empty, show usage and stop.
 
 2. **Snapshot the running command and its tmux session.** SSH to the pod and capture both:
    ```
@@ -24,13 +33,14 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
    ```
    Save this output — it goes into the cron prompt so the babysitter agent knows the session name and exact command to restart.
 
-3. **Create the cron job.** Use `CronCreate` with cron `*/5 * * * *` (every 5 min), recurring: true. The prompt must be **completely self-contained** — the cron agent has no conversation history. Build it from this template:
+3. **Create the cron job.** Use `CronCreate` with cron `*/5 * * * *` (every 5 min), recurring: true. The prompt must be **completely self-contained** — the cron agent has no conversation history. Build it from this template (omit the `--on-complete` block if not provided):
 
    ```
    You are babysitting a GPU job on pod "{pod_name}" (SSH: `runpod-{pod_name}`).
 
    **What's running:** {description}
    **Last known command:** {snapshot from step 2}
+   {if on_complete: **On completion, fire this prompt:** {on_complete}}
 
    ## Check
 
@@ -45,8 +55,9 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
       d. If crashed → restart using the last known command above inside a new tmux session (`tmux new-session -d -s <session> '<cmd>'`). Report what happened.
 
    4. **If done** (all expected outputs exist per the description):
-      a. Report completion.
-      b. Pause the pod: invoke `/zombuul:pause-runpod {pod_name}`.
+      a. Report completion (one line + total runtime if you can derive it).
+      b. {if on_complete: Enqueue the follow-up via `CronCreate(cron="<minute+1> <hour> <day> <month> *", recurring=false, prompt="{on_complete}")` so it fires once, ~1 minute from now. Do NOT pause the pod — the follow-up is responsible for any syncing/pausing.}
+         {else: Pause the pod by invoking `/zombuul:pause-runpod {pod_name}`.}
       c. Cancel this cron job: use `CronList` to find the job whose prompt mentions "{pod_name}", then `CronDelete <id>`.
 
    Keep output to 1-3 lines unless something went wrong.
@@ -54,7 +65,11 @@ Monitor a long-running GPU job on a RunPod pod, restarting on crash and cleaning
 
 4. **Run the first check immediately** — execute the same SSH process check inline so the user gets instant feedback. Don't wait for the first cron tick.
 
-5. **Report:** Show the cron job ID, what it's monitoring, and `CronDelete <id>` to cancel.
+5. **Report:** Show the cron job ID, what it's monitoring, whether an on-complete is wired up, and `CronDelete <id>` to cancel.
+
+## Why on-complete doesn't pause the pod
+
+The follow-up prompt typically needs to rsync results from the pod before pausing — and you can't rsync from a paused pod (SSH is dead). So when `--on-complete` is set, babysit's success branch hands off to the follow-up with the pod still alive, and the follow-up handles its own pause as the final step. Without on-complete, babysit pauses immediately because no further work is queued.
 
 ## Report zombuul bugs
 

--- a/skills/finalize-experiment/SKILL.md
+++ b/skills/finalize-experiment/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: zombuul:finalize-experiment
+description: >
+  Finalize an experiment after the main work is done — sync pod results back, run analysis,
+  spawn report review, commit and push. Argument $ARGUMENTS — `<spec_path> [--pod <pod_name>]`.
+  Invoked automatically by `/zombuul:babysit --on-complete` when a long-running job finishes,
+  or directly by you when an experiment doesn't use a babysitter (no pod, no cron).
+user-invocable: true
+---
+
+You are finalizing an experiment that has finished running. The main work — generation, training, extraction, whatever the spec called for — is already done. Your job is to sync any remote results, analyze them, write or finish the report, get it reviewed, and commit/push the deliverable.
+
+## Arguments
+
+`$ARGUMENTS` is `<spec_path> [--pod <pod_name>]`.
+
+- `spec_path` (required): path to the experiment spec, e.g. `experiments/foo/foo_spec.md`. The experiment directory is its parent.
+- `--pod <pod_name>` (optional): if the experiment ran on a RunPod pod, pass its SSH alias name (matching `runpod-<pod_name>`). Triggers a pod-result sync followed by a pause. Omit for purely local experiments.
+
+## Read history first — don't fly blind
+
+Before doing anything, read these files in order. They are your only source of truth for what happened during the run:
+
+1. `<spec_path>` — what the experiment was supposed to do.
+2. `experiments/<name>/running_log.md` — what was actually done, what was decided mid-run, what was skipped, what surprised the kickoff agent. Read it end to end. If it references commits or git history, run `git log --oneline -20 -- experiments/<name>/` to fill in.
+3. `experiments/<name>/<name>_report.md` if it already exists (the kickoff agent may have started it at major milestones).
+4. The output files (whatever the spec said the experiment would produce — measurements, scores, JSONL, .npz, etc.).
+
+You do not have the kickoff agent's working memory. The running log is how that memory was preserved for you. Treat any decision noted there (parameter changes, scope reductions, controls deferred) as load-bearing context that must be reflected in the report.
+
+## Workflow
+
+### F1: Sync results (pod-only)
+
+If `--pod <pod_name>` was provided:
+
+1. Verify the pod is alive: `ssh runpod-<pod_name> 'tmux ls 2>/dev/null; echo done'`. If it's paused (SSH fails), that's a problem — the babysitter was supposed to leave it running for you. Resume it once via `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py resume <pod_id>` (look up pod_id with `runpod_ctl.py list`).
+2. Determine which directories to sync. The spec's "Output structure" / per-cell results path is the canonical source. Default for most experiments: `rsync -az runpod-<pod_name>:/workspace/repo/experiments/<name>/results/ experiments/<name>/results/`. Add other gitignored output dirs the spec produced.
+3. After sync, pause the pod: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>` (or `/zombuul:pause-runpod <pod_name>` — equivalent).
+
+If no `--pod` flag (purely local experiment, or `IS_SANDBOX=1` meaning you're already on the pod): skip F1.
+
+### F2: Analyze
+
+Run any analysis script the spec or running_log point to (typically `scripts/<name>/analyze.py` or similar). The kickoff agent should have left analysis code in place; if not, write it. Sanity-check outputs (counts, magnitudes, no NaNs) before building the report on top of them.
+
+If results look wrong (counts off, magnitudes implausible, refusal rates that suggest a broken cell), do NOT paper over it in the report. Flag it in the report and, if needed, re-run the affected piece.
+
+### F3: Write or finish the report
+
+Path: `experiments/<name>/<name>_report.md`. Plots go in `experiments/<name>/assets/` and are referenced with relative paths: `![desc](assets/plot_<mmddyy>_<short_desc>.png)`.
+
+**Report style.** Scannable — someone should grasp the full arc in 30 seconds. Headlines over prose, tables over text, dead ends in one line each. Include plots at key checkpoints. Include enough detail to reproduce (parameters, prompts, configs) but stay concise. Favor results (numbers, tables, plots) over interpretive prose — keep interpretation to short inline remarks or a few bullets, not dedicated sections. The reviewer subagent (next step) will catch clarity issues — focus on content first.
+
+**Plotting.** Delegate plot creation to subagents (Agent tool, subagent_type="general-purpose", model="opus"). Describe what to plot, where the data is, and where to save it. The subagent writes the script (under `scripts/<name>/`) and runs it. Keeps plotting code out of your context.
+
+**Compute, don't transcribe.** Never hand-write numbers in the report. Generate tables and metrics programmatically from the data files. If a number changes after a re-run, the report should pick it up automatically.
+
+**Report honestly.** Null and negative results are informative. Spec deviations (parameter changes, scope reductions, controls deferred) recorded in the running log must appear in the report as a "deviations from spec" or similar paragraph.
+
+### F4: Review
+
+Spawn an Agent (subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to the report. Apply the feedback. Do not skip this — even a one-pass review catches missing context, ambiguous claims, and unsupported conclusions.
+
+### F5: Commit and push (cherry-pick-friendly ordering)
+
+The deliverable is `experiments/<name>/` (spec, report, assets, running log). It should be cleanly cherry-pickable to main without dragging in code/script/results changes that may not be ready to merge.
+
+**Convention:** every commit that touches `experiments/<name>/` should ONLY touch `experiments/<name>/`. Code, scripts, results files, and config changes go in separate commits.
+
+Order:
+1. Commit code/scripts/data artifacts in separate, meaningfully-labeled commits. Respect `.gitignore`. Files >50 MB that aren't already gitignored should be added to `.gitignore` rather than committed.
+2. A final commit containing only `experiments/<name>/` — the deliverable.
+3. `git push -u origin HEAD`.
+
+This lets the user pull the deliverable onto main with: `git checkout <branch> -- experiments/<name>/ && git commit`.
+
+No PR for the report itself. PRs are reserved for cases where the experiment also produced reusable code worth reviewing.
+
+## Rules
+
+- **Read the running log first.** Without it, you are guessing about decisions made during the run.
+- **Reuse existing analysis code** under `scripts/<name>/` rather than writing new analyses. If the kickoff agent already drafted `analyze.py`, use it; only extend it for things it didn't cover.
+- **Compute, don't transcribe.** Numbers in the report come from data files via code, not from your context.
+- **Report honestly.** Spec deviations, null results, surprising findings all belong in the report. Do not spin or omit.
+- **Don't game the spec.** If a metric in the spec is unmeasurable from the data you have, say so in the report — don't substitute a similar-looking metric without flagging the swap.
+- **Do not ask the user.** Make reasonable choices and note them. The user invoked finalize expecting it to run to completion.
+
+## Report zombuul bugs
+
+If anything went wrong this session that zombuul could plausibly have done better, follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` before ending.

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -144,12 +144,7 @@ Keep commits small and labeled (`log: <step>`, `result: <step>`, `fix: <what>`).
 
 ### OP3: Finish
 
-1. Run `/zombuul:review-experiment-report` via an Agent subagent on the report path.
-2. Final commits + push (cherry-pick-friendly ordering, see [Commit ordering](#commit-ordering)):
-   1. First, commit code/scripts/data artifacts (separate commits, labeled meaningfully). Respect `.gitignore`; large files that aren't already gitignored should be added to `.gitignore` rather than committed.
-   2. Then, a final commit containing only `experiments/{name}/` — the deliverable.
-   3. `git push -u origin HEAD`.
-3. Exit cleanly. The launch script will pause the pod automatically.
+Hand off to `/zombuul:finalize-experiment <spec_path>` (no `--pod` — `IS_SANDBOX=1` means you're already on the pod; results don't need syncing). Finalize handles the report, the review, and the cherry-pick-friendly commit ordering. Exit cleanly when finalize returns. The launch script will pause the pod automatically on exit.
 
 ## Execution model
 
@@ -169,8 +164,8 @@ For GPU jobs expected to take more than ~10 minutes, launch inside tmux + invoke
 
 1. Launch the job in a named tmux session (pick `<session>` to match the job, e.g. `extraction`):
    `ssh runpod-<name> "tmux new-session -d -s <session> 'cd /workspace/repo && python -u -m <module> > <log_path> 2>&1'"`
-2. Invoke `/zombuul:babysit <pod_name> <description>` — this sets up a cron job that checks every 5 min, restarts on crash, and pauses the pod when done. Include the tmux session name in the description so babysit can check liveness via `tmux has-session`.
-3. You are free to work on other tasks while the babysitter monitors. It will report progress and any issues to the conversation.
+2. Invoke `/zombuul:babysit <pod_name> <description> --on-complete "/zombuul:finalize-experiment <spec_path> --pod <pod_name>"`. The `--on-complete` flag is the resumption hook: when the cron detects the job has finished cleanly, it fires that prompt as a one-shot, which re-enters the workflow at the finalize step (sync results → pause pod → analyze → review → commit). Include the tmux session name in the description so babysit can check liveness via `tmux has-session`.
+3. You are free to work on other tasks while the babysitter monitors. It will report progress and any issues to the conversation. **Do NOT continue to the workflow's tail steps yourself** — finalize-experiment will fire when the job is done.
 
 **Audit on launch:**
 When you launch a long-running job (extraction, training, generation, steering), immediately spawn an audit subagent (Agent tool, subagent_type="general-purpose", model="opus") in the background. The subagent checks the setup independently — it should not trust your assumptions. Pass it the spec and the paths to all data/config files being used. The subagent should:
@@ -242,39 +237,17 @@ All scripts you write during this experiment go here — experiment runners, ana
 
 **Plotting**: Delegate plot creation to subagents (Agent tool, subagent_type="general-purpose", model="opus"). Describe what to plot and where to save it — the subagent writes the script and runs it. This keeps plotting code out of your context.
 
-## Report style guide
-
-Scannable — someone should grasp the full arc in 30 seconds. Headlines over prose, tables over text, dead ends in one line each. Include plots at key checkpoints (save to `assets/`). Include enough detail to reproduce (parameters, prompts, configs) but stay concise. Favor results (numbers, tables, plots) over interpretive prose — keep interpretation to short inline remarks or a few bullets, not dedicated sections. The `/zombuul:review-experiment-report` subagent will catch clarity issues — focus on content first.
-
 ## Workflow
 
 1. **Setup** (Phase 1 + Phase 2 for local mode; R1–R4 for remote-launcher; OP1 for on-pod).
 2. **Read the spec.** Set up infrastructure.
 3. Create scripts workspace, report skeleton, and running log.
 4. Run baseline, then iterate. Log each step to the running log. Update the report at major milestones with plots. If an approach fails, log it and pivot.
-5. **Review the report.** Launch a subagent (Agent tool, subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to `report.md`. Do not skip this step.
-6. **Sync results** (local mode only, if a pod was used): sync all results back locally. Pause the pod via `/zombuul:pause-runpod`.
-7. **Commit and push** (cherry-pick-friendly ordering, see [Commit ordering](#commit-ordering)):
-   1. First, commit code/scripts/data artifacts (separate commits, labeled meaningfully).
-   2. Then, a final commit containing only `experiments/{name}/` — the deliverable.
-   3. `git push -u origin HEAD`.
-   Check `.gitignore` before committing large files. If you generate data files that exceed ~50MB and aren't already gitignored, add them to `.gitignore` rather than committing. (In on-pod mode you've already been pushing incrementally — this final push just tops it off.)
-
-## Commit ordering
-
-The experiment runs on a worktree branch but the deliverable — `experiments/{name}/` (spec, report, assets, running log) — should land on `main` without dragging in code/script/results changes that may not be ready to merge.
-
-**Convention:** every commit that touches `experiments/{name}/` should ONLY touch `experiments/{name}/`. Code, scripts, results files, and config changes go in separate commits. (On-pod mode's incremental `log:` commits already follow this — they're scoped via `git add experiments/<name>/`.)
-
-This lets the user pull the deliverable to main with a single path-scoped checkout — works regardless of how many commits touched the experiment dir:
-
-```
-git checkout <experiment-branch> -- experiments/{name}/ && git commit
-```
-
-In local mode, where the experiment dir is typically created in one final commit, `git cherry-pick <final-experiment-commit-sha>` also works.
-
-No PR required for the report itself. PRs are reserved for cases where the experiment also produced reusable code worth reviewing.
+5. **Hand off to finalize.**
+   - Local mode with babysit: babysit's `--on-complete` fires `/zombuul:finalize-experiment <spec_path> --pod <pod_name>` automatically. Stop here — finalize will handle sync, analysis, report, review, commit.
+   - Local mode without babysit (short job): when the work is done, invoke `/zombuul:finalize-experiment <spec_path> --pod <pod_name>` directly.
+   - On-pod mode: invoke `/zombuul:finalize-experiment <spec_path>` (no `--pod`).
+   - Local mode with no pod at all: invoke `/zombuul:finalize-experiment <spec_path>` directly.
 
 ## Sizing a pod from the spec
 


### PR DESCRIPTION
Move post-completion workflow (sync/analyze/report/review/commit) out of run-experiment into a new finalize-experiment skill. Add --on-complete to babysit so cron success branch fires a follow-up prompt instead of self-cancelling. Run-experiment delegates to finalize in every mode.