### PR TITLE
chore: handle GitHub username rename ogilg → oscar-gilg

### DIFF
--- a/.github/workflows/simplify.yml
+++ b/.github/workflows/simplify.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    if: github.actor == 'ogilg'
+    if: github.actor == 'oscar-gilg'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,4 +35,4 @@ Skills are auto-discovered from `skills/`. Each skill is a directory with a `SKI
 
 ## Agent-authored issues
 
-The main user-invocable skills point agents at `REPORTING_BUGS.md`, which tells them to file GitHub issues autonomously when zombuul itself hits friction, even in someone else's repo. Expect a steady stream at https://github.com/ogilg/zombuul/issues — treat them as field telemetry, close/dedupe liberally.
+The main user-invocable skills point agents at `REPORTING_BUGS.md`, which tells them to file GitHub issues autonomously when zombuul itself hits friction, even in someone else's repo. Expect a steady stream at https://github.com/oscar-gilg/zombuul/issues — treat them as field telemetry, close/dedupe liberally.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Zombuul
 
-![Clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ogilg/zombuul/main/.github/clone-count.json)
+![Clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/oscar-gilg/zombuul/main/.github/clone-count.json)
 
 Run AI safety experiments end-to-end, from spec to report. Claude Code handles the GPU pod, orchestration, and writeup. Locally, or fully remote.
 
 ## Install
 
 ```
-/plugin marketplace add ogilg/zombuul
+/plugin marketplace add oscar-gilg/zombuul
 /plugin install zombuul@ogilg-marketplace
 ```
 
@@ -64,6 +64,6 @@ You (local Claude Code)              Pod (RunPod GPU)
 
 ## Feedback
 
-Bugs, questions, feature ideas, or just want to share what you're running: all welcome. Open an [issue](https://github.com/ogilg/zombuul/issues) or start a [discussion](https://github.com/ogilg/zombuul/discussions). I read everything.
+Bugs, questions, feature ideas, or just want to share what you're running: all welcome. Open an [issue](https://github.com/oscar-gilg/zombuul/issues) or start a [discussion](https://github.com/oscar-gilg/zombuul/discussions). I read everything.
 
 Contact: `oscar.gilg18 [at] gmail [dot] com` / [@gilg_oscar](https://x.com/gilg_oscar) on X

--- a/REPORTING_BUGS.md
+++ b/REPORTING_BUGS.md
@@ -11,7 +11,7 @@ If during this session anything went wrong that zombuul could plausibly have don
 ## How
 
 ```
-gh issue create --repo ogilg/zombuul \
+gh issue create --repo oscar-gilg/zombuul \
   --title "<short>" \
   --body "<what happened + concrete command/error + suggested fix if obvious>"
 ```
@@ -25,6 +25,6 @@ Document it well. At minimum:
 ## Conventions
 
 - Batch multiple small papercuts from one session into a single issue rather than filing five separate ones.
-- Before filing, skim recent open issues (`gh issue list --repo ogilg/zombuul --state open --limit 20`) and add a comment to an existing one instead of duplicating.
+- Before filing, skim recent open issues (`gh issue list --repo oscar-gilg/zombuul --state open --limit 20`) and add a comment to an existing one instead of duplicating.
 - Tell the user in one line that you're filing so they can override ("Filing a zombuul issue about the `.env` parse error — let me know if you'd rather I skip it.").
 - Don't block on this — it's a reflection at session end or after hitting the bug, not during active work.

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -137,7 +137,7 @@ if [ "$INSTALL_CLAUDE" = "true" ]; then
     install_zombuul() {
         # Remove stale marketplace if present (idempotent re-install)
         claude plugin marketplace remove ogilg-marketplace 2>/dev/null || true
-        claude plugin marketplace add ogilg/zombuul || return 1
+        claude plugin marketplace add oscar-gilg/zombuul || return 1
         claude plugin install zombuul@ogilg-marketplace || return 1
     }
     retry "install zombuul plugin" 3 10 install_zombuul


### PR DESCRIPTION
## Summary

The GitHub account renamed from `ogilg` to `oscar-gilg`. Most refs work via GitHub's redirect, but one is silently broken:

- **`.github/workflows/simplify.yml`** — `if: github.actor == 'ogilg'` gates the Simplify Review job, so every PR (including #74) shows the check as `SKIPPED`. Updated to `oscar-gilg`.

Cosmetic / forward-looking fixes:
- `REPORTING_BUGS.md`: `gh issue create/list --repo` paths.
- `README.md`: clone-count badge URL, install command, issues/discussions links.
- `scripts/pod_setup.sh`: `claude plugin marketplace add` repo path.
- `CLAUDE.md`: agent-authored-issues URL.

Left alone:
- `ogilg-marketplace` / `ogilg-marketplace-dev` everywhere — marketplace identifier, not a username; renaming would invalidate other users' install paths.
- `.claude-plugin/plugin.json` author URL + repository URL, and `.claude-plugin/marketplace.json` `owner.name` — these are release-cherry-picked at dev → main, so a fix on dev would revert at next release. Needs a separate edit on main.

## Test plan
- [ ] After merge, open a fresh PR and confirm the Simplify Review check actually runs (not SKIPPED).
- [ ] Follow-up PR to main updating `plugin.json` URLs and `marketplace.json` `owner.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)