### PR TITLE
run-experiment: hard rule to re-arm Monitor on timeout

### DIFF
--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -159,6 +159,8 @@ Hand off to `/zombuul:finalize-experiment <spec_path>` (no `--pod` — `IS_SANDB
 - Short commands (<10 min): use `run_in_background` on the Bash tool. You get notified when they complete.
 - While waiting: prepare next steps, write analysis code, set up plotting scripts.
 
+**Monitor timeouts:** if you ever see `[Monitor timed out — re-arm if needed.]` in your context, your literal next tool call must be a fresh `Monitor` on the same target. Do not run any other tool, do not summarize, do not check progress first. Re-arm, then resume.
+
 **Babysitting long GPU jobs (local mode only):**
 For GPU jobs expected to take more than ~10 minutes, launch inside tmux + invoke babysit instead of using `run_in_background`. tmux sessions survive SSH drops; babysit handles crash recovery.
 


### PR DESCRIPTION
## Summary

- Adds a one-line rule under "Execution model" in `run-experiment/SKILL.md`: when the agent sees `[Monitor timed out — re-arm if needed.]`, the literal next tool call must be a fresh `Monitor` on the same target.

## Why

Across multiple recent sessions (e081, d694, ff5d, cd8b, 02e1) Monitor would time out and the agent would continue with other tool calls — never re-arming — which silently lost visibility into long-running pod jobs. This is a behavioral fix, not infra: the prompt simply mandates re-arming as the next action.

## Test plan
- [ ] Land it. Next time Monitor times out during run-experiment, the agent should re-arm before doing anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)