### PR TITLE
scripts: add safe_rsync.sh wrapper; use it from the sync skills

### DIFF
--- a/scripts/safe_rsync.sh
+++ b/scripts/safe_rsync.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# safe_rsync.sh — thin rsync wrapper that always emits a parseable summary.
+#
+# Usage:  safe_rsync.sh <rsync args...>
+#
+# Forces `--stats`, captures output, and prints a final line:
+#     [safe_rsync] EXIT=<code> FILES=<n>
+# regardless of whether the caller pipes through tail/head. Lets agents tell
+# at a glance whether the transfer actually moved anything — bare `rsync`
+# calls have been silently swallowed by `| tail -5` and exit-code checks
+# while a missing source dir or malformed args produced 0 files.
+
+set -uo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "[safe_rsync] usage: safe_rsync.sh <rsync args...>" >&2
+    exit 64
+fi
+
+out=$(mktemp -t safe_rsync.XXXXXX)
+trap 'rm -f "$out"' EXIT
+
+rsync --stats "$@" 2>&1 | tee "$out"
+rc=${PIPESTATUS[0]}
+
+n=$(grep -m1 -E "^Number of (regular )?files transferred:" "$out" | sed 's/[^0-9]//g')
+n=${n:-?}
+
+echo "[safe_rsync] EXIT=$rc FILES=$n"
+exit "$rc"

--- a/skills/finalize-experiment/SKILL.md
+++ b/skills/finalize-experiment/SKILL.md
@@ -35,7 +35,7 @@ You do not have the kickoff agent's working memory. The running log is how that 
 If `--pod <pod_name>` was provided:
 
 1. Verify the pod is alive: `ssh runpod-<pod_name> 'tmux ls 2>/dev/null; echo done'`. If it's paused (SSH fails), that's a problem — the babysitter was supposed to leave it running for you. Resume it once via `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py resume <pod_id>` (look up pod_id with `runpod_ctl.py list`).
-2. Determine which directories to sync. The spec's "Output structure" / per-cell results path is the canonical source. Default for most experiments: `rsync -az runpod-<pod_name>:/workspace/repo/experiments/<name>/results/ experiments/<name>/results/`. Add other gitignored output dirs the spec produced.
+2. Determine which directories to sync. The spec's "Output structure" / per-cell results path is the canonical source. Default for most experiments: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/safe_rsync.sh -az runpod-<pod_name>:/workspace/repo/experiments/<name>/results/ experiments/<name>/results/`. Add other gitignored output dirs the spec produced. Each invocation prints `[safe_rsync] EXIT=<code> FILES=<n>`; check both lines before proceeding — `EXIT=0 FILES=0` on a finalize sync usually means you're syncing the wrong path or the experiment didn't write what the spec said it would.
 3. After sync, pause the pod: `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>` (or `/zombuul:pause-runpod <pod_name>` — equivalent).
 
 If no `--pod` flag (purely local experiment, or `IS_SANDBOX=1` meaning you're already on the pod): skip F1.

--- a/skills/provision-pod/SKILL.md
+++ b/skills/provision-pod/SKILL.md
@@ -50,9 +50,11 @@ Provision a RunPod pod after creation. Handles SSH config, waits for setup to co
 
    Launch all of the following concurrently using `run_in_background`, then wait for all to complete:
 
-   - **Sync .env to repo** (if `.env` exists in current working directory): `rsync -az --no-owner --no-group .env runpod-<pod_name>:/workspace/repo/.env`
-   - **Sync experiment spec** (if `spec_path` provided): `ssh runpod-<pod_name> 'mkdir -p /workspace/repo/<spec_parent_dir>' && rsync -az --no-owner --no-group <spec_path> runpod-<pod_name>:/workspace/repo/<spec_path>`
-   - **Sync data directories** (one per directory from `data_dirs`): `rsync -az --no-owner --no-group <local_dir>/ runpod-<pod_name>:/workspace/repo/<remote_dir>/` — note trailing slashes to copy contents.
+   - **Sync .env to repo** (if `.env` exists in current working directory): `bash ${CLAUDE_PLUGIN_ROOT}/scripts/safe_rsync.sh -az --no-owner --no-group .env runpod-<pod_name>:/workspace/repo/.env`
+   - **Sync experiment spec** (if `spec_path` provided): `ssh runpod-<pod_name> 'mkdir -p /workspace/repo/<spec_parent_dir>' && bash ${CLAUDE_PLUGIN_ROOT}/scripts/safe_rsync.sh -az --no-owner --no-group <spec_path> runpod-<pod_name>:/workspace/repo/<spec_path>`
+   - **Sync data directories** (one per directory from `data_dirs`): `bash ${CLAUDE_PLUGIN_ROOT}/scripts/safe_rsync.sh -az --no-owner --no-group <local_dir>/ runpod-<pod_name>:/workspace/repo/<remote_dir>/` — note trailing slashes to copy contents.
+
+   Each `safe_rsync.sh` invocation prints a final line `[safe_rsync] EXIT=<code> FILES=<n>` (regardless of `| tail`). Verify each sync's `EXIT=0` and check `FILES`. A non-zero exit means the sync failed; `FILES=0` on a first-time sync of a non-empty source means the source path is wrong or empty.
 
 5. **Report**: Once all background tasks complete, report:
    - SSH command: `ssh runpod-<pod_name>`

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -151,7 +151,7 @@ Hand off to `/zombuul:finalize-experiment <spec_path>` (no `--pod` — `IS_SANDB
 **Local mode — remote vs local command awareness:**
 - GPU-bound commands (model loading, extraction, training, steering) → SSH to pod: `ssh runpod-<name> 'cd /workspace/repo && python -m ...'`
 - CPU-bound commands (analysis, plotting, fitting) → run locally
-- Results from pod need to be synced back: `rsync -az runpod-<name>:/workspace/repo/<results_path> <local_path>`
+- Results from pod need to be synced back: `bash ${CLAUDE_PLUGIN_ROOT}/scripts/safe_rsync.sh -az runpod-<name>:/workspace/repo/<results_path> <local_path>` (the wrapper prints `[safe_rsync] EXIT=<code> FILES=<n>` so you can confirm the transfer actually moved files)
 
 **On-pod mode:** everything runs locally on the pod. No SSH, no rsync.
 


### PR DESCRIPTION
## Summary

- New `scripts/safe_rsync.sh`: thin wrapper around `rsync --stats` that always emits one final line:
  ```
  [safe_rsync] EXIT=<code> FILES=<n>
  ```
  regardless of whether the caller pipes through `| tail`. The wrapper itself takes no policy stance.
- Replaced bare `rsync` calls in `provision-pod`, `run-experiment`, and `finalize-experiment` with `safe_rsync.sh`. Skill text now explicitly tells agents to check `EXIT=0` and `FILES`.

## Why

Recurring failure mode: agents call `rsync ... 2>&1 | tail -5`, the actual error message gets swallowed, and the call returns success-looking output. Examples from the last week:
- A missing remote source path produced an "empty file list" warning that didn't reach the agent's notice.
- `data_dirs` syncs in `provision-pod` ran in parallel with no per-dir validation; one silently failed, the on-pod run later hit MISSING DATA.
- A malformed-arg case where rsync apparently printed help text, triggering a misdiagnose loop.

The wrapper gives every rsync call a single, parseable, tail-resistant summary. The agent (and skill) decide what to do with it; the wrapper doesn't fail on `FILES=0` (idempotent re-syncs legitimately transfer 0).

## Out of scope

- Babysit's auto-backup loop has no rsync in the skill (the behavior is emergent agent improvisation). Not touching it here.
- Retry-on-transient-codes (12, 30 etc.) — left for a possible future iteration; the wrapper just exits with rsync's code.
- Post-sync `du` validation in `provision-pod`. Worth doing eventually but adds enough surface to deserve its own PR.

## Test plan
- [x] Local: confirms `EXIT=0 FILES=2` on first sync, `EXIT=0 FILES=0` on re-sync, `EXIT=23 FILES=0` on missing source.
- [ ] Next provision-pod run: confirm the summary line shows up in each Phase B sync's background output.
- [ ] Next finalize-experiment with `--pod`: confirm sync emits the summary line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)