### PR TITLE
ci: add Simplify Review workflow

### DIFF
--- a/.github/workflows/simplify.yml
+++ b/.github/workflows/simplify.yml
@@ -1,0 +1,55 @@
+name: Simplify Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  review:
+    if: github.actor == 'oscar-gilg'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: anthropics/claude-code-action@main
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools Read,Glob,Grep,Bash,Edit,Write,mcp__github_inline_comment__create_inline_comment,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review
+          prompt: |
+            Review this PR aggressively for reuse, quality, and efficiency. Deliver concrete improvements — don't just list concerns.
+
+            First, get the diff: `git diff origin/${{ github.base_ref }}...HEAD`. Search the repo for relevant existing utilities before suggesting new code.
+
+            What to flag:
+            - **Reuse**: new code duplicating an existing utility — name the existing function and propose the swap.
+            - **Quality**: redundant state; parameter sprawl; copy-paste with slight variation; leaky abstractions; stringly-typed code where constants/enums exist; nested conditionals 3+ deep; comments explaining WHAT or narrating the change (keep only non-obvious WHY).
+            - **Efficiency**: redundant computation; missed concurrency; hot-path bloat; no-op state updates inside loops; TOCTOU pre-checks; memory leaks; overly broad operations.
+
+            How to deliver — split into TWO buckets:
+
+            1. **Commit directly to the PR branch** for changes that are safe and don't require author judgment: dead code removal, dedup against an existing utility, comment removal (WHAT-explainers and change-narrators), trivial renames, mechanical refactors. Rules:
+               - One commit per logical change. Keep commits small and reviewable.
+               - Commit message format: `simplify: <imperative summary>` (e.g. `simplify: dedupe path normalization via existing helper`). The `simplify:` prefix is mandatory — it's how the author filters/reverts your work.
+               - Body: brief WHY the change is correct (1-3 lines).
+               - Push commits to the PR head branch.
+
+            2. **Inline `suggestion` block** (GitHub PR review comment) for changes that need author judgment: refactor approaches, API shape, anything behavior-affecting, anything you're <90% sure is safe. The author gets a one-click apply button.
+
+            If unsure which bucket: use suggestion, not commit.
+
+            **At the end, post a single top-level PR review comment** with:
+            - "Committed" section: bulleted list of `<sha>` `<commit message>` for each commit you pushed.
+            - "Suggested" section: brief list of suggestion-block comments you left.
+            - "Skipped" section: anything you considered but rejected (one line each).
+
+            This summary is the author's audit trail — be complete.
+
+            Be aggressive on what to flag, conservative on what to commit.


### PR DESCRIPTION
## Summary

Bring the Simplify Review workflow over from dev so GitHub's workflow-validation step (which reads from the default branch) finds a matching file when the action runs on PRs.

## Why

PRs against `dev` (#76, #77, #78, #79) all surfaced "Simplify Review/review: SUCCESS" but the action skipped early with:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

Default branch is `main`, and `simplify.yml` was dev-only. After this lands, the next push to a dev PR should actually run the review.

## Safety

- Actor-gated: `if: github.actor == 'oscar-gilg'`. Other users' PRs are no-ops.
- Auth via `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max plan), not pay-as-you-go API.

## History

Squashes the dev iteration (PRs #68, #69, #70, #75) into one commit reflecting the final state.

## Test plan
- [ ] After merge, push a trivial commit to one of the open dev PRs (#76–#79) and confirm the Simplify Review action actually executes (commits or comments appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)