### PR TITLE
README: drop clones badge from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Zombuul
 
-![Clones](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/oscar-gilg/zombuul/main/.github/clone-count.json)
-
 Run AI safety experiments end-to-end, from spec to report. Claude Code handles the GPU pod, orchestration, and writeup. Locally, or fully remote.
 
 ## Install


### PR DESCRIPTION
Removes the unique-cloners badge from the top of the README. Doesn't touch the underlying clone-count workflow or JSON state files — just unlinks the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)