### PR TITLE
runpod_ctl: enable SSH keep-alive to prevent edge-proxy idle disconnects

### DIFF
--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 print = functools.partial(print, flush=True)
 
 SSH_KEY = "~/.ssh/id_ed25519"
-SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5"]
+SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5", "-o", "ServerAliveInterval=30", "-o", "ServerAliveCountMax=10"]
 USER_CONFIG = "~/.claude/zombuul.yaml"
 VALID_CONFIG_KEYS = {"volume_gb", "disk_gb", "docker_image", "gpu_count", "cpu_instance_id", "python_version", "ssh_key", "template_id"}
 
@@ -297,6 +297,8 @@ def _write_ssh_alias(name: str, ip: str, port: int) -> None:
         f"    Port {port}\n"
         f"    IdentityFile {SSH_KEY}\n"
         f"    StrictHostKeyChecking no\n"
+        f"    ServerAliveInterval 30\n"
+        f"    ServerAliveCountMax 10\n"
     )
     cfg_path = os.path.expanduser("~/.ssh/config")
     if not os.path.exists(cfg_path):

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -16,7 +16,9 @@ from dotenv import load_dotenv
 print = functools.partial(print, flush=True)
 
 SSH_KEY = "~/.ssh/id_ed25519"
-SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5", "-o", "ServerAliveInterval=30", "-o", "ServerAliveCountMax=10"]
+_SSH_ALIVE_INTERVAL = 30
+_SSH_ALIVE_COUNT_MAX = 10
+SSH_OPTS = ["-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=5", "-o", f"ServerAliveInterval={_SSH_ALIVE_INTERVAL}", "-o", f"ServerAliveCountMax={_SSH_ALIVE_COUNT_MAX}"]
 USER_CONFIG = "~/.claude/zombuul.yaml"
 VALID_CONFIG_KEYS = {"volume_gb", "disk_gb", "docker_image", "gpu_count", "cpu_instance_id", "python_version", "ssh_key", "template_id"}
 
@@ -297,8 +299,8 @@ def _write_ssh_alias(name: str, ip: str, port: int) -> None:
         f"    Port {port}\n"
         f"    IdentityFile {SSH_KEY}\n"
         f"    StrictHostKeyChecking no\n"
-        f"    ServerAliveInterval 30\n"
-        f"    ServerAliveCountMax 10\n"
+        f"    ServerAliveInterval {_SSH_ALIVE_INTERVAL}\n"
+        f"    ServerAliveCountMax {_SSH_ALIVE_COUNT_MAX}\n"
     )
     cfg_path = os.path.expanduser("~/.ssh/config")
     if not os.path.exists(cfg_path):


### PR DESCRIPTION
Closes #59.

## Diagnosis

Long-running SSH commands (extractions, syncs, on-pod measurements) were returning exit 255 — the issue framed this as "SSH session closing after agent finished." That diagnosis isn't quite right: a clean SSH disconnect bubbles up the remote command's exit code, not 255. Exit 255 specifically means SSH transport failure. The most likely cause is RunPod's edge proxy idle-timing-out a connection that's quiet for too long (no traffic during a long compute), killing the transport mid-command.

## Fix

Add `ServerAliveInterval=30` + `ServerAliveCountMax=10` in two places:

1. The SSH config alias block written by `_write_ssh_alias`. Every `ssh runpod-<name>` invocation inherits keep-alive automatically.
2. `SSH_OPTS` for the launch-time helpers that SSH directly via `-p PORT -i KEY` before the alias exists (`setup_pod` etc).

Result: keep-alive packets every 30s, 5 minutes of grace before declaring the connection dead. No new wrapper, no skill-text changes, no marker-file machinery.

## Migration

Existing aliases pick up the new options next time they're rewritten — i.e. on `create` / `resume` / `refresh-ssh`. For a stale alias on a long-running pod, run `python scripts/runpod_ctl.py refresh-ssh <pod_name>`.

## Why not a wrapper script

The issue suggests fancier fixes (remote exit-code marker file, retry on 255). I'd hold those for if keep-alive turns out to be insufficient. Most reported false-failures look consistent with idle-disconnect, and keep-alive is one config line per affected place.

## Test plan
- [ ] On the next pod, run a long SSH command (e.g. `ssh runpod-<pod> 'sleep 120; echo done'`) and confirm no 255 surface from the local Bash tool.
- [ ] Re-run a sync/extraction sequence that previously triggered exit-255 notifications and watch the rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)