### PR TITLE
ci + skills: pre-rollout hardening for MATS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
@@ -26,5 +26,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Shellcheck pod_setup.sh
-        run: shellcheck scripts/pod_setup.sh
+      - name: Shellcheck all scripts/*.sh
+        run: shellcheck scripts/*.sh
+
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate plugin manifests and skill frontmatter
+        run: python scripts/validate_plugin.py

--- a/scripts/launch_on_pod.sh
+++ b/scripts/launch_on_pod.sh
@@ -11,6 +11,7 @@ SPEC_PATH="${2:?Usage: launch_on_pod.sh <branch> <spec_path>}"
 
 # Load env (RUNPOD_POD_ID, RUNPOD_API_KEY, HF_TOKEN, GH_TOKEN, etc.) before
 # registering the trap so pause_pod has access to them.
+# shellcheck source=/dev/null
 source ~/.bash_profile
 
 pause_pod() {
@@ -20,7 +21,7 @@ pause_pod() {
 }
 trap pause_pod EXIT
 
-cd /workspace/repo
+cd /workspace/repo || exit 1
 git checkout "$BRANCH"
 git pull origin "$BRANCH"
 

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate plugin.json, marketplace.json, and every SKILL.md frontmatter.
+
+Stdlib-only. Exits non-zero on any failure with one FAIL line per issue.
+Intended to run in CI before a release ships.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    FAILURES.append(msg)
+
+
+def validate_plugin_json() -> None:
+    path = REPO_ROOT / ".claude-plugin" / "plugin.json"
+    if not path.exists():
+        fail(f"{path}: missing")
+        return
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        fail(f"{path}: invalid JSON — {e}")
+        return
+    for key in ("name", "version", "description", "repository", "license"):
+        if key not in data:
+            fail(f"{path}: missing required key '{key}'")
+
+
+def validate_marketplace_json() -> None:
+    path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    if not path.exists():
+        fail(f"{path}: missing")
+        return
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        fail(f"{path}: invalid JSON — {e}")
+        return
+    for key in ("name", "owner", "plugins"):
+        if key not in data:
+            fail(f"{path}: missing required key '{key}'")
+    plugins = data.get("plugins", [])
+    if not isinstance(plugins, list) or not plugins:
+        fail(f"{path}: 'plugins' must be a non-empty array")
+        return
+    for i, p in enumerate(plugins):
+        for key in ("name", "source", "description"):
+            if key not in p:
+                fail(f"{path}: plugins[{i}] missing required key '{key}'")
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+_TOP_LEVEL_KEY_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9_-]*):", re.MULTILINE)
+
+
+def split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return (frontmatter_block, body) or None if no frontmatter."""
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def frontmatter_keys(frontmatter: str) -> set[str]:
+    """Return the set of top-level keys (lines starting at column 0 with `key:`).
+
+    This is a permissive parser: it ignores values, multi-line folded scalars,
+    and comments. We only need to know which keys are present.
+    """
+    return {m.group(1) for m in _TOP_LEVEL_KEY_RE.finditer(frontmatter)}
+
+
+def frontmatter_value(frontmatter: str, key: str) -> str | None:
+    """Return the raw single-line value for `key`, or None if not single-line."""
+    pat = re.compile(rf"^{re.escape(key)}:\s*(.+?)\s*$", re.MULTILINE)
+    m = pat.search(frontmatter)
+    if not m:
+        return None
+    val = m.group(1).strip()
+    # Skip multi-line indicators (folded/literal scalars).
+    if val in (">", "|", ">-", "|-"):
+        return None
+    return val
+
+
+def validate_skills() -> None:
+    skills_dir = REPO_ROOT / "skills"
+    if not skills_dir.exists():
+        fail(f"{skills_dir}: missing")
+        return
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        rel = skill_md.relative_to(REPO_ROOT)
+        if not skill_md.exists():
+            fail(f"{rel}: missing")
+            continue
+        text = skill_md.read_text()
+        split = split_frontmatter(text)
+        if split is None:
+            fail(f"{rel}: missing or malformed YAML frontmatter (expected ---/---)")
+            continue
+        frontmatter, body = split
+        keys = frontmatter_keys(frontmatter)
+        for required in ("name", "description", "user-invocable"):
+            if required not in keys:
+                fail(f"{rel}: missing required frontmatter field '{required}'")
+        name_val = frontmatter_value(frontmatter, "name")
+        expected_name = f"zombuul:{skill_dir.name}"
+        if name_val is not None and name_val != expected_name:
+            fail(
+                f"{rel}: name '{name_val}' does not match expected "
+                f"'{expected_name}' (skill directory: {skill_dir.name})"
+            )
+        if "argument-hint" in keys and "$ARGUMENTS" not in body:
+            fail(
+                f"{rel}: declares 'argument-hint' but body does not reference "
+                f"$ARGUMENTS"
+            )
+
+
+def main() -> int:
+    validate_plugin_json()
+    validate_marketplace_json()
+    validate_skills()
+    if FAILURES:
+        for line in FAILURES:
+            print(f"FAIL: {line}")
+        print(f"\n{len(FAILURES)} validation failure(s).", file=sys.stderr)
+        return 1
+    print("OK: plugin.json, marketplace.json, and all SKILL.md files validate.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/pause-runpod/SKILL.md
+++ b/skills/pause-runpod/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: zombuul:pause-runpod
 description: "Pause a RunPod pod: stop GPU billing; keep /workspace only (container disk is wiped on resume)."
-argument-hint: "[pod-name]"
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---

--- a/skills/resume-runpod/SKILL.md
+++ b/skills/resume-runpod/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: zombuul:resume-runpod
 description: Resume a paused RunPod pod.
-argument-hint: "[pod-name]"
 user-invocable: true
 allowed-tools: Bash, AskUserQuestion
 ---

--- a/skills/review-spec/SKILL.md
+++ b/skills/review-spec/SKILL.md
@@ -9,19 +9,23 @@ user-invocable: true
 
 Review this experiment spec for practical readiness: $ARGUMENTS
 
+> Adapt these checks to your domain. Not every item applies to every spec — skip items that don't match the spec's methodology (e.g., the train/eval/test integrity check is irrelevant for a single-pass analysis).
+
 ## Proportionality
 
-**Scale review depth to spec complexity.** A 25-line extraction or analysis spec does not need the same scrutiny as a 100-line multi-phase experiment. Before launching agents, read the spec and estimate complexity:
+**Scale review depth to spec complexity.** A 25-line single-step spec does not need the same scrutiny as a 100-line multi-phase experiment. Before launching agents, read the spec and estimate complexity:
 
-- **Simple** (~25-40 lines, single step, local execution, existing modules): focus on code pointer verification only (Agent 3). Skip Agents 1 and 2 — their checklists add noise for straightforward specs. Return a brief pass/fail on whether the referenced code exists and the parameters are specified.
-- **Medium** (40-80 lines, 2-3 steps, may need GPU): run all three agents but tell Agents 1 and 2 to keep output to pass/fail items only — no "suggested additions" unless something is actually missing.
+- **Simple** (~25–40 lines, single step, local execution, existing modules): run only Agent 2 (code pointer verification). Skip Agent 1 — its checklist adds noise for straightforward specs. Return a brief pass/fail on whether the referenced code exists and the parameters are specified.
+- **Medium** (40–80 lines, 2–3 steps, may need GPU): run both agents but tell Agent 1 to keep output to pass/fail items only — no "suggested additions" unless something is actually missing.
 - **Complex** (80+ lines, multi-phase, novel methodology): full review as described below.
 
 ## What to do
 
-Read the spec, `README.md`, and `CLAUDE.md`. Then launch subagents as appropriate for the complexity level above. For medium and complex specs, launch **three parallel subagents** (Agent tool, subagent_type="general-purpose"). Each simulates reading the spec with zero prior context — pass only the spec + README + CLAUDE.md contents, nothing else.
+Read the spec, `README.md`, and `CLAUDE.md`. Then launch subagents as appropriate for the complexity level above. For medium and complex specs, launch **two parallel subagents** (Agent tool, subagent_type="general-purpose"). Agent 1 simulates reading the spec with zero prior context — pass only the spec + README + CLAUDE.md contents, nothing else. Agent 2 has access to the repo to verify code pointers.
 
-### Shared preamble (include in all three prompts)
+### Agent 1: Spec quality (zero-context reviewer)
+
+Append to the shared preamble:
 
 ```
 You are reviewing an experiment spec that will be executed by local Claude Code, with optional GPU pod access for compute-heavy steps. The spec is the sole guide for the experiment.
@@ -40,21 +44,15 @@ Here is the project CLAUDE.md:
 <claude_md>
 {CLAUDE.md contents}
 </claude_md>
-```
 
-### Agent 1: Code & data validation
-
-Append to the shared preamble:
-
-```
-Review ONLY the following two aspects. Flag what's missing or unclear.
+Review the spec across the sections below. Flag what's missing or unclear. Adapt items to the spec's domain — not every check applies to every spec.
 
 ### 1. Code reuse
 
 This is the most important check. Without explicit code pointers, the executor will reimplement things that already exist — and get subtle details wrong.
 
 - Does **every** pipeline step reference a specific module, function, or entry point? Vague references like "use the existing pipeline" or "the standard method" are not enough — the spec must name the exact module or function.
-- Are there "do not reimplement" warnings for key infrastructure (extraction, probe training, steering, measurement, elicitation)?
+- Are there "do not reimplement" warnings for key pipeline infrastructure (e.g., data preprocessing, training, evaluation, analysis)?
 - If the spec says "use X", check whether the README/CLAUDE.md confirms X exists.
 - If a step could plausibly be done by existing code but the spec doesn't mention it, flag it — the executor will write new code instead of reusing what exists.
 
@@ -64,26 +62,12 @@ This is the most important check. Without explicit code pointers, the executor w
 - Or does it confirm that no extra data sync is needed?
 - Are input file paths listed explicitly?
 
-## Output
+### 3. Parameter values
 
-1. **Pass/fail** per item (one line each)
-2. **Issues** — quote the problematic text and suggest a fix
-3. **Suggested additions** — concrete text the user can paste into the spec
-```
-
-### Agent 2: Practical pitfalls
-
-Append to the shared preamble:
-
-```
-Review ONLY the following aspects. Flag what's missing or unclear.
-
-### 1. Missing parameter values
-
-- Are all required parameters specified (model name, layers, batch sizes, sample counts, coefficient ranges)?
+- Are all required parameters specified (model name, layers, batch sizes, sample counts, coefficient ranges, hyperparameters)?
 - Are there ambiguous references ("the existing pipeline", "the standard method") without specific pointers?
 
-### 2. Formats and conventions
+### 4. Formats and conventions
 
 This is where experiments most often go wrong silently. Flag any of these that are unspecified:
 
@@ -93,27 +77,28 @@ This is where experiments most often go wrong silently. Flag any of these that a
 - Config file structure (if the step is config-driven, does the spec show the config or point to an example?)
 - Naming conventions for output files
 
-### 3. GPU memory requirements
+### 5. Compute / memory requirements
 
 - Does the experiment involve model loading? If so, is VRAM likely sufficient for the described setup?
 - Are there batch size / sequence length choices that might OOM?
+- For non-GPU work: are wall-clock and memory expectations realistic?
 
-### 4. Success criteria
+### 6. Success criteria
 
 - How do we know when the experiment is done?
 - Are there clear metrics or thresholds?
 
-### 5. Data integrity
+### 7. Data integrity
 
-- Are training, validation, and test sets explicitly defined as disjoint? If splits are mentioned, is the separation enforced at the right level (e.g., by group, not by individual observation)?
-- If results from one stage feed into another (e.g., selection → evaluation, measurement → steering), is the methodology (prompts, parameters, parsing, scoring) consistent across stages — or is the deviation documented?
+- Are training, validation, and test sets explicitly defined as disjoint (if applicable)? If splits are mentioned, is the separation enforced at the right level (e.g., by group, not by individual observation)?
+- If results from one stage feed into another (e.g., stage A → stage B), is the methodology (prompts, parameters, parsing, scoring) consistent across stages — or is the deviation documented?
 
-### 6. Silent failure risks
+### 8. Silent failure risks
 
-- Steps that could fail silently (e.g., empty results, wrong tensor shapes, mismatched task IDs)
+- Steps that could fail silently (e.g., empty results, wrong tensor shapes, mismatched task IDs, mis-parsed responses)
 - Missing sanity checks
 
-### 7. Pre-mortem: what could go wrong?
+### 9. Pre-mortem: what could go wrong?
 
 Assume the experiment runs to completion but produces a useless or misleading result. Think adversarially:
 
@@ -126,12 +111,12 @@ For each risk, suggest a concrete mitigation.
 
 ## Output
 
-1. **Pass/fail** per item (one line each)
+1. **Pass/fail** per section (one line each)
 2. **Issues** — quote the problematic text and suggest a fix
 3. **Suggested additions** — concrete text the user can paste into the spec
 ```
 
-### Agent 3: Verify code pointers exist
+### Agent 2: Verify code pointers exist
 
 This agent searches the actual repo — it does NOT get the zero-context constraint.
 
@@ -150,13 +135,13 @@ For each code reference in the spec, report:
 Only report code references. Do not review anything else.
 ```
 
-## After all three agents return
+## After both agents return
 
 Merge the results into a single review:
 
-1. **Pass/fail summary** — one line per checklist item (code reuse, data requirements, parameters, formats/conventions, GPU memory, success criteria, silent failures, pre-mortem risks)
+1. **Pass/fail summary** — one line per checklist item (code reuse, data requirements, parameters, formats/conventions, compute/memory, success criteria, data integrity, silent failures, pre-mortem risks)
 2. **Code pointer verification** — which references exist, which don't
-3. **Issues** — combined from agents 1 and 2, deduplicated
-4. **Suggested additions** — combined from agents 1 and 2
+3. **Issues** — from Agent 1
+4. **Suggested additions** — from Agent 1
 
 Present to the user.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -44,17 +44,31 @@ Use `[ ]` for missing items. Only proceed to Phase 3 if there are missing items.
 
 ## Phase 3: Fix missing items (only if needed)
 
-For each missing item:
+For each missing item, attempt the primary fix. If it fails, fall back to the manual instructions and tell the user exactly what to do.
 
-- **No package manager**: install uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`); if uv is unavailable, fall back to pip
-- **No SSH key**: If they have a key at a different path (e.g. `~/.ssh/id_rsa`), set `ssh_key` in `~/.claude/zombuul.yaml`. Otherwise generate one: `ssh-keygen -t ed25519`
-- **No runpod**: install with available package manager
-- **No RUNPOD_API_KEY**: direct to https://www.runpod.io/console/user/settings → API Keys, collect via AskUserQuestion, write to the project `.env` (preferred, since it gets synced to pods) or `~/.claude/.env`
-- **No Claude Code credentials**: try `security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json`. If that fails, tell them to copy manually.
-- **No .env / missing fields**: create template with required (GH_TOKEN, GIT_USER_NAME, GIT_USER_EMAIL) and optional (HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID) fields. Collect missing required fields via AskUserQuestion.
+- **No package manager**:
+  - Primary: install uv with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+  - Fallback (if curl fails / no network / script errors): direct the user to https://docs.astral.sh/uv/getting-started/installation/ for OS-specific install. If they can't install uv, pip is acceptable — only fail setup if neither is available.
+- **No SSH key**:
+  - Primary: if they have a key at a different path (e.g. `~/.ssh/id_rsa`), set `ssh_key` in `~/.claude/zombuul.yaml`. Otherwise generate one: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ""`.
+  - Fallback (if `ssh-keygen` interactive prompt fails or the file already exists): tell the user to run `ssh-keygen -t ed25519` manually in a terminal, then re-run setup.
+- **No runpod**:
+  - Primary: install with available package manager (`uv pip install runpod` or `pip install runpod`).
+  - Fallback (network/permissions error): tell the user to run the pip install in a terminal with appropriate venv/permissions, then re-run setup.
+- **No RUNPOD_API_KEY**:
+  - Primary: direct to https://www.runpod.io/console/user/settings → API Keys, collect via AskUserQuestion, write to the project `.env` (preferred, since it gets synced to pods) or `~/.claude/.env`.
+  - Fallback (no key available now): write the `.env` file with a `RUNPOD_API_KEY=` placeholder and stop. Tell the user to fill it in, then re-run setup.
+- **No Claude Code credentials**:
+  - Primary (macOS): `security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json`.
+  - Fallback (non-macOS / Keychain entry missing): tell the user to copy `~/.claude/.credentials.json` manually from another machine where Claude Code is logged in, or to run `claude` and complete login first, then re-run setup.
+- **No .env / missing fields**:
+  - Primary: create template with required (GH_TOKEN, GIT_USER_NAME, GIT_USER_EMAIL) and optional (HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID) fields. Collect missing required fields via AskUserQuestion.
+  - Fallback (user doesn't have a GH_TOKEN handy): write the file with a placeholder and point them at https://github.com/settings/tokens — they can fill in later, but pod cloning won't work until they do.
 - **No dependency file**: warn that pod setup expects a `pyproject.toml`, `requirements.txt`, or `setup.py` in the repo root. Dependencies will be skipped on the pod if none are present.
-- **No ralph-wiggum**: ask if wanted; if yes, `/plugin marketplace add anthropics/claude-code` then install ralph-loop
-- **No config file**: copy `${CLAUDE_PLUGIN_ROOT}/defaults.yaml` to `~/.claude/zombuul.yaml`
+- **No ralph-wiggum**: ask if wanted; if yes, `/plugin marketplace add anthropics/claude-code` then install ralph-loop. (Not a hard prerequisite — skip if the user declines.)
+- **No config file**:
+  - Primary: copy `${CLAUDE_PLUGIN_ROOT}/defaults.yaml` to `~/.claude/zombuul.yaml`.
+  - Fallback (defaults.yaml not found — broken install): tell the user to reinstall zombuul (`/plugin update zombuul`).
 
 ## Phase 4: Customize pod defaults
 
@@ -85,13 +99,20 @@ Run this command to verify the RunPod API key works:
 python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py gpus
 ```
 
-If it fails, help debug (wrong key, missing package, etc.).
+If it fails, match the error to one of the common failure modes below and tell the user exactly what to fix:
+
+- **HTTP 401 / "Unauthorized"** → bad or revoked API key. Re-collect via AskUserQuestion (the user can generate a new key at https://www.runpod.io/console/user/settings → API Keys) and rewrite the `.env`.
+- **HTTP 403 / "Forbidden"** → key valid but account access denied (often: unpaid balance or suspended account). Point them to https://www.runpod.io/console/billing.
+- **`ModuleNotFoundError: No module named 'runpod'`** → the runpod package isn't installed. Re-run the Phase 3 "No runpod" fix step.
+- **`Connection refused` / DNS resolution / timeout** → network issue. Ask the user to check their internet / corporate proxy. If they're behind a proxy, suggest setting `HTTPS_PROXY` in their shell.
+- **`KeyError: 'RUNPOD_API_KEY'` or empty output before any request** → the env var isn't loaded. Confirm the key is in `.env` (in the current working directory) or `~/.claude/.env`, and that the line is `RUNPOD_API_KEY=...` with no quotes or trailing whitespace.
+- **Other error** → show the raw output to the user and offer to open a GitHub issue at https://github.com/oscar-gilg/zombuul/issues.
 
 ## Phase 6: Summary
 
 If everything is configured, tell the user they're ready and show:
 ```
-/launch-research-pod experiments/<name>/<name>_spec.md
+/zombuul:run-experiment experiments/<name>/<name>_spec.md
 ```
 
 Tell them to create a `{name}_spec.md` first if they don't have one.

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: zombuul:smoke-test
+description: >
+  End-to-end smoke test of zombuul. Runs pre-flight checks, then spawns 3 parallel
+  agents that exercise API connectivity, pod listing, and full pod lifecycle (launch,
+  SSH, GPU sanity check, pause). Use before publishing a release. Takes ~5–10 minutes
+  and costs roughly $0.05 in RunPod GPU time.
+user-invocable: true
+allowed-tools: Bash, Agent, Read
+---
+
+Run a pre-release smoke test of zombuul. Goal: confirm the basic plumbing (API key, scripts, pod lifecycle) still works end-to-end before shipping to other users. Not a substitute for real testing — but catches the obvious "everything is broken" cases in under 10 minutes.
+
+## Pre-flight (serial, fast)
+
+Run these checks before launching anything. Abort with a clear message if any fail.
+
+1. **API key present**: Check that `RUNPOD_API_KEY` is set in either `.env` (in the current working directory) or `~/.claude/.env`.
+   - If missing: stop. Tell the user to run `/zombuul:setup` first.
+
+2. **Scripts importable**: Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py --help` and confirm exit code 0.
+   - If non-zero: stop. The likely cause is a missing `runpod` Python package or a broken script. Tell the user to re-run `/zombuul:setup`.
+
+3. **SSH key present**: Read `ssh_key` path from `~/.claude/zombuul.yaml` (default `~/.ssh/id_ed25519`). Confirm the file exists.
+   - If missing: stop. Tell the user to run `/zombuul:setup`.
+
+If all three pass, announce that smoke test is starting and report the unique smoke-test pod name you'll use (e.g., `smoke-<unix_timestamp>`).
+
+## Parallel agents
+
+Spawn three subagents in parallel using the Agent tool (`subagent_type="general-purpose"`, `run_in_background=true`). Each agent gets a self-contained prompt with the exact bash commands and pass criterion below. **Do not have agents invoke any `/zombuul:*` slash command** — they call `runpod_ctl.py` directly. This isolates the smoke test from skill orchestration logic.
+
+### Agent A — API connectivity
+
+Prompt:
+
+> Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py gpus` and capture stdout.
+>
+> **Pass criterion**: command exits 0 AND the output lists at least one GPU type (look for substring patterns like "RTX" or "A100" or "H100" or a non-empty line that looks like a GPU id).
+>
+> Report a single-line result: `A (API) PASS — <one-sentence summary>` or `A (API) FAIL — <reason>` with the command output included if it failed.
+
+### Agent B — Pod listing
+
+Prompt:
+
+> Run `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py list` and capture stdout.
+>
+> **Pass criterion**: command exits 0. Output is allowed to say "no pods running" or list pods — either is fine.
+>
+> Report a single-line result: `B (list) PASS — <count> pods` or `B (list) FAIL — <reason>` with the command output included if it failed.
+
+### Agent C — Full pod lifecycle (GPU)
+
+Prompt:
+
+> You are running a full pod lifecycle smoke test. Use the unique pod name `<smoke_pod_name>` (passed in below). Do NOT reuse an existing pod.
+>
+> **Steps:**
+>
+> 1. Read `~/.claude/zombuul.yaml` for default GPU type. If a `gpu_type` field is set, use it. Otherwise call `runpod_ctl.py gpus` and pick the cheapest GPU type (lowest `$/hr`).
+>
+> 2. Create the pod:
+>    `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py create --name <smoke_pod_name> --gpu <gpu_type>`.
+>    Capture the pod_id from the output.
+>
+> 3. Wait for setup:
+>    `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py wait-setup <pod_id> --timeout 600`.
+>
+> 4. Run the GPU sanity check over SSH:
+>    `ssh runpod-<smoke_pod_name> 'nvidia-smi --query-gpu=name --format=csv,noheader'`.
+>    Capture the output.
+>
+> 5. Pause the pod:
+>    `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>`.
+>
+> **Pass criterion**: step 4 returns a non-empty GPU name AND step 5 exits 0.
+>
+> **Cleanup on failure**: if any step fails, attempt `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py pause <pod_id>` (idempotent — pause is safe even mid-setup). If pause also fails, attempt `python ${CLAUDE_PLUGIN_ROOT}/scripts/runpod_ctl.py terminate <pod_id> --yes`. Report any leaked pods in the failure message.
+>
+> Report a single-line result: `C (pod e2e) PASS — <gpu_name>, paused as <smoke_pod_name>` or `C (pod e2e) FAIL — <step> — <reason>`. Include any leaked-pod warning.
+
+## Wait, then report
+
+Wait for all three agents to complete. Print a summary block:
+
+```
+Zombuul smoke test results:
+  A (API)      PASS/FAIL — ...
+  B (list)     PASS/FAIL — ...
+  C (pod e2e)  PASS/FAIL — ...
+
+Overall: PASS/FAIL
+```
+
+If any test failed AND the failure looks like a zombuul bug (not a user-environment issue), follow `${CLAUDE_PLUGIN_ROOT}/REPORTING_BUGS.md` to file an issue before ending.
+
+If C left a pod running (cleanup couldn't pause it), call this out loudly in the final report so the user can terminate it manually.


### PR DESCRIPTION
## Summary

Small batch of low-risk hardening before sharing zombuul with MATS researchers. Plan: `/Users/oscargilg/.claude/plans/i-think-simplifying-review-fluffy-moler.md`.

- **CI**: runs on `dev` pushes; shellchecks all `scripts/*.sh`; new `validate` job runs `scripts/validate_plugin.py` (stdlib-only) that checks `plugin.json`, `marketplace.json`, and every `SKILL.md` frontmatter (required fields, name matches dir, `$ARGUMENTS` consistency).
- **New `/zombuul:smoke-test` skill**: pre-flight + 3 parallel subagents (API connectivity, pod listing, full pod lifecycle with GPU sanity check). Scripts-only — no recursion into `/zombuul:run-experiment`. ~5–10 min, ~$0.05.
- **`review-spec`**: domain-agnostic vocab (drops interp-specific terms), merges the two zero-context reviewer agents into one (preserves all 9 checklist items). Agent 2 (code pointer verification with repo access) stays separate.
- **`setup`**: fix bogus `/launch-research-pod` reference; enumerate common Phase 5 API failure modes (401/403/ModuleNotFound/network/missing-env); add fallback instructions for every Phase 3 fix step.
- **Drive-bys**: drop misleading `argument-hint` from `pause-runpod`/`resume-runpod` (surfaced by validator); fix two shellcheck warnings in `launch_on_pod.sh` (surfaced by broader glob).

## Test plan

- [x] `python scripts/validate_plugin.py` exits 0 on current tree
- [x] Negative test: stripped `description:` from a SKILL.md → validator exits 1 with clear FAIL line → restored
- [x] `shellcheck scripts/*.sh` exits 0 after launch_on_pod.sh fixes
- [ ] CI passes on this PR (validate + shellcheck + test jobs all green)
- [ ] `/zombuul:smoke-test` in a fresh session: A/B pass under 30s, C completes pod lifecycle in <10 min, pod ends paused
- [ ] `/zombuul:setup` on a project with intentional missing config: confirm fallback messages fire and summary shows the corrected `/zombuul:run-experiment` command

## Out of scope (filed as follow-up issues)

- PR-based workflow for `run-experiment`
- `examples/` directory with canned spec + report
- Cost transparency at pod launch / pause
- Setup-as-doctor (re-running setup on a healthy config should be a no-op pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)