### PR TITLE
ci: auto-bump dev version on every push

### DIFF
--- a/.github/workflows/version-bump-dev.yml
+++ b/.github/workflows/version-bump-dev.yml
@@ -1,0 +1,51 @@
+name: Version Bump (dev)
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  bump:
+    # Skip on bump commits to avoid infinite loop
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0
+
+      - name: Bump dev pre-release counter
+        id: bump
+        run: |
+          NEW_VERSION=$(python3 - <<'PY'
+          import json, re, sys
+          path = ".claude-plugin/plugin.json"
+          with open(path) as f:
+              d = json.load(f)
+          v = d["version"]
+          # Expect <X.Y.Z>-dev or <X.Y.Z>-dev.<N>; bump or initialise the counter.
+          m = re.match(r"^(\d+\.\d+\.\d+)-dev(?:\.(\d+))?$", v)
+          if not m:
+              sys.exit(f"unexpected dev version format: {v}")
+          base, n = m.group(1), m.group(2)
+          new = f"{base}-dev.{int(n) + 1 if n else 1}"
+          d["version"] = new
+          with open(path, "w") as f:
+              json.dump(d, f, indent=2)
+              f.write("\n")
+          print(new)
+          PY
+          )
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: bump dev version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ Two long-lived branches:
 
 **Dev-only files that must not merge to main:**
 - `.claude-plugin/marketplace.json` — `name` is `ogilg-marketplace-dev` on dev, `ogilg-marketplace` on main
-- `.claude-plugin/plugin.json` — `version` has `-dev` suffix on dev
+- `.claude-plugin/plugin.json` — `version` has `-dev` suffix on dev (format `X.Y.Z-dev` or `X.Y.Z-dev.N`)
+
+**Dev version auto-bumps.** `.github/workflows/version-bump-dev.yml` increments the `-dev.N` counter on every push to `dev`, so each dev commit has a unique version. Without this, `claude plugin update zombuul@ogilg-marketplace-dev` is a silent no-op (the plugin manager compares version strings). When syncing main → dev, resolve the `plugin.json` conflict to `X.Y.Z-dev` (main's patch + `-dev`, no counter) — the next push to dev auto-bumps to `X.Y.Z-dev.1`.
 
 **Never:**
 - PR a feature branch directly to main (go through dev).


### PR DESCRIPTION
## Summary

Adds `.github/workflows/version-bump-dev.yml` mirroring the existing `version-bump.yml` on main. On every push to dev, bumps a pre-release counter in `plugin.json`:

```
1.1.21-dev -> 1.1.21-dev.1 -> 1.1.21-dev.2 -> ...
```

Without this, `claude plugin update zombuul@ogilg-marketplace-dev` was a silent no-op when dev had new commits but the version string was unchanged (the plugin manager compares version strings to decide whether to refresh the cache). With this, every dev commit has a unique version and updates work natively — no manual cache clearing needed.

CLAUDE.md updated to document the new format and the main → dev sync conflict resolution (reset to `X.Y.Z-dev`; first push auto-bumps to `.1`).

## Verification

- [x] Regex tested locally on `1.1.21-dev`, `1.1.21-dev.1`, `1.1.21-dev.99`, `1.1.24-dev`, and `1.1.23` (last rejected, as expected for non-dev versions).
- [ ] After merge: confirm the bump workflow fires on the merge commit and pushes `1.1.21-dev.1` to dev.
- [ ] Then `claude plugin update zombuul@ogilg-marketplace-dev` should detect the new version and refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)