### PR TITLE
ci: PR-based auto-bump for main and dev (fix #96)

### DIFF
--- a/.github/workflows/version-bump-dev.yml
+++ b/.github/workflows/version-bump-dev.yml
@@ -1,12 +1,11 @@
-name: Version Bump
+name: Version Bump (dev)
 
 on:
   push:
-    branches: [main]
+    branches: [dev]
 
 jobs:
   bump:
-    # Skip on bump-merge commits to break the loop.
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     permissions:
@@ -19,16 +18,20 @@ jobs:
           token: ${{ secrets.PAT }}
           fetch-depth: 0
 
-      - name: Bump patch version
+      - name: Bump dev pre-release counter
         id: bump
         run: |
           NEW=$(python3 - <<'PY'
-          import json
+          import json, re, sys
           path = ".claude-plugin/plugin.json"
           with open(path) as f:
               d = json.load(f)
-          major, minor, patch = d["version"].split(".")
-          new = f"{major}.{minor}.{int(patch) + 1}"
+          v = d["version"]
+          m = re.match(r"^(\d+\.\d+\.\d+)-dev(?:\.(\d+))?$", v)
+          if not m:
+              sys.exit(f"unexpected dev version format: {v}")
+          base, n = m.group(1), m.group(2)
+          new = f"{base}-dev.{int(n) + 1 if n else 1}"
           d["version"] = new
           with open(path, "w") as f:
               json.dump(d, f, indent=2)
@@ -37,9 +40,9 @@ jobs:
           PY
           )
           echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
-          echo "BRANCH=auto/bump-main-$NEW" >> "$GITHUB_ENV"
+          echo "BRANCH=auto/bump-dev-$NEW" >> "$GITHUB_ENV"
 
-      - name: Push branch, tag, open auto-merge PR
+      - name: Push branch, open auto-merge PR
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
@@ -47,12 +50,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add .claude-plugin/plugin.json
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
-          git tag "v${{ steps.bump.outputs.new_version }}"
+          git commit -m "chore: bump dev version to ${{ steps.bump.outputs.new_version }}"
           git push -u origin "$BRANCH"
-          git push origin "v${{ steps.bump.outputs.new_version }}"
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore: bump version to ${{ steps.bump.outputs.new_version }}" \
-            --body "Auto-bump after merge to main."
+          gh pr create --base dev --head "$BRANCH" \
+            --title "chore: bump dev version to ${{ steps.bump.outputs.new_version }}" \
+            --body "Auto-bump for plugin cache busting on dev."
           gh pr merge "$BRANCH" --auto --merge \
-            --subject "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
+            --subject "chore: bump dev version to ${{ steps.bump.outputs.new_version }} [skip ci]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 Two long-lived branches:
 
-- **`main`** — production. Tracked by other users' plugin installs (`ogilg-marketplace`). Moves only on deliberate release PRs. Branch-protected (PR required, no force-pushes, no deletions). The `version-bump.yml` workflow auto-bumps the patch version on every merge to main.
-- **`dev`** — integration branch for the maintainer's own testing. Tracked by the maintainer's local install via `ogilg-marketplace-dev` (git URL source with `ref: dev`). Branch-protected identically to main (PR required, no force-pushes, no deletions).
+- **`main`** — production. Tracked by other users' plugin installs (`ogilg-marketplace`). Moves only on deliberate release PRs. Branch-protected (PR required, no force-pushes, no deletions). The `version-bump.yml` workflow opens an auto-merging bump PR after every merge to main; that PR bumps the patch in `plugin.json` and tags the release.
+- **`dev`** — integration branch for the maintainer's own testing. Tracked by the maintainer's local install via `ogilg-marketplace-dev` (git URL source with `ref: dev`). Branch-protected identically to main (PR required, no force-pushes, no deletions). The `version-bump-dev.yml` workflow opens an auto-merging bump PR after every merge to dev, incrementing the `-dev.N` counter — this is what makes `claude plugin update zombuul@ogilg-marketplace-dev` see new commits without manual cache-clearing.
 
 **Making edits — always:**
 1. `git checkout dev && git pull`
@@ -23,9 +23,9 @@ Two long-lived branches:
 
 **Dev-only files that must not merge to main:**
 - `.claude-plugin/marketplace.json` — `name` is `ogilg-marketplace-dev` on dev, `ogilg-marketplace` on main
-- `.claude-plugin/plugin.json` — `version` has `-dev` suffix on dev
+- `.claude-plugin/plugin.json` — `version` has `-dev` suffix on dev (format `X.Y.Z-dev` or `X.Y.Z-dev.N`)
 
-**Refreshing the dev install.** Dev's `plugin.json` version stays constant across pushes, so `claude plugin update zombuul@ogilg-marketplace-dev` is a silent no-op when dev has new commits. Workaround: `rm -rf ~/.claude/plugins/cache/ogilg-marketplace-dev/zombuul/<version>/` then update. Proper fix tracked at the open "PR-based dev auto-bump" issue.
+When syncing main → dev, resolve the `plugin.json` conflict to `<main-patch>-dev` (no counter) — the next dev push auto-bumps to `<main-patch>-dev.1`.
 
 **Never:**
 - PR a feature branch directly to main (go through dev).


### PR DESCRIPTION
## Summary

Closes #96. Refactors version-bump workflows to respect branch protection: no direct pushes to main or dev — bumps go through auto-merging PRs.

### Changes

**`.github/workflows/version-bump.yml`** (refactor):
- Fires on push to main (skips `[skip ci]` commits)
- Bumps patch + tags the bump commit on feature branch \`auto/bump-main-X.Y.Z\`
- Opens PR, calls \`gh pr merge --auto --merge --subject "...[skip ci]"\` so the merge commit's subject breaks the loop

**`.github/workflows/version-bump-dev.yml`** (new):
- Same shape, but bumps the \`-dev.N\` pre-release counter (e.g. \`1.1.24-dev\` → \`1.1.24-dev.1\` → \`...-dev.2\`)
- No tagging (tags are for main releases only)
- Fixes the silent-no-op problem when refreshing dev installs

**Repo-level**: `allow_auto_merge` enabled (was false). `gh pr merge --auto` needs it.

**`CLAUDE.md`**: updated to describe the new flow and the simplified main → dev sync resolution (`<main-patch>-dev`, next push bumps to `.1`).

## What's not in this PR (next step)

Once this merges and we've verified the new dev workflow actually fires on a subsequent dev push, we should also flip `enforce_admins=true` on `main` (it's currently `false`). That closes the door on direct pushes uniformly. I'd do that as a manual settings change once we have confidence.

## Test plan

- [x] YAML parses locally for both workflows
- [x] Bump logic regex tested against `1.1.24-dev`, `1.1.21-dev.99`, `1.1.24` (last rejected for dev workflow as expected)
- [x] `python scripts/validate_plugin.py` passes
- [ ] CI green on this PR
- [ ] After merge to dev: the new `version-bump-dev.yml` fires on the merge commit, opens an auto-merge bump PR for `1.1.24-dev.1`, CI on that PR passes, auto-merge fires, dev ends at `1.1.24-dev.1`
- [ ] `claude plugin update zombuul@ogilg-marketplace-dev` now detects the new version automatically (no manual cache-clear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)