### PR TITLE
ci: fire on any push; drop flaky pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 
+# Fire on every push. The pull_request trigger was unreliable on PR open
+# (~40% of PRs today saw no CI dispatch until we pushed an empty commit).
+# push events fire reliably, and GitHub associates check runs with PRs by
+# head SHA so branch protection sees them as PR checks just the same.
 on:
   push:
-    branches: [main, dev]
-  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Three of eight PRs today (#94, #98, #100) opened with no CI dispatch — `pull_request` event silently dropped. Each needed a manual empty-commit push to recover. The `push` event has been reliable in every case we've seen.

This PR drives CI off `push:` to any branch and drops the flaky `pull_request:` trigger. GitHub associates check runs with PRs by head SHA regardless of which event fires them, so branch protection still sees test/shellcheck/validate as the PR's required checks.

Adds a `concurrency:` group with `cancel-in-progress: true` to dedupe wasted runs when a branch gets multiple rapid pushes (e.g., the empty-commit retrigger pattern would otherwise run CI twice).

## Trade-offs

- **Loses CI on PRs from forks.** Pushes to a fork's repo don't fire workflows on ours. Not relevant today (no external contributors); easy to re-add `pull_request:` later if it becomes one.
- **CI now runs on every feature-branch push.** Previously only on push to main/dev + PR events. This is a tiny increase in compute (most feature branches already had a PR firing CI anyway) and `concurrency:` keeps it from doubling up.

## Test plan

- [x] YAML parses
- [ ] CI fires on this PR's push (would be ironic if not)
- [ ] After merge, next dev push triggers CI as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)