### PR TITLE
skills: experiment-as-PR flow

### DIFF
--- a/skills/finalize-experiment/SKILL.md
+++ b/skills/finalize-experiment/SKILL.md
@@ -63,20 +63,47 @@ Path: `experiments/<name>/<name>_report.md`. Plots go in `experiments/<name>/ass
 
 Spawn an Agent (subagent_type="general-purpose", model="opus") with `/zombuul:review-experiment-report`, passing the path to the report. Apply the feedback. Do not skip this — even a one-pass review catches missing context, ambiguous claims, and unsupported conclusions.
 
-### F5: Commit and push (cherry-pick-friendly ordering)
+### F5: Data inventory + outside-code-changes (in the report)
 
-The deliverable is `experiments/<name>/` (spec, report, assets, running log). It should be cleanly cherry-pickable to main without dragging in code/script/results changes that may not be ready to merge.
+Before final commit, append two short sections to the report.
 
-**Convention:** every commit that touches `experiments/<name>/` should ONLY touch `experiments/<name>/`. Code, scripts, results files, and config changes go in separate commits.
+**Data used.** From the spec's input paths, run `du -sh <path>` on each and list:
 
-Order:
+```
+## Data used
+- activations/<dir>/ (2.3G)
+- probe_data/<dir>/ (45M)
+```
+
+Skip the section entirely if the experiment has no gitignored inputs.
+
+**Code changes outside this experiment.** Run `git diff <pr-base-branch>...HEAD --name-only -- ':!experiments/<name>/' ':!scripts/<name>/'`. If non-empty, append:
+
+```
+## Code changes outside this experiment
+Modified while running. These are not in this PR — open a separate one:
+- <path>
+- <path>
+```
+
+The user uses this list to spin off a follow-up PR with just the code changes. Don't include diffs, just paths.
+
+### F6: Commit and push (experiment folder is the deliverable)
+
+The deliverable is `experiments/<name>/` (spec, report, assets, running log). Order commits so the experiment-folder diff is clean and self-contained — easy to read in the PR UI.
+
 1. Commit code/scripts/data artifacts in separate, meaningfully-labeled commits. Respect `.gitignore`. Files >50 MB that aren't already gitignored should be added to `.gitignore` rather than committed.
 2. A final commit containing only `experiments/<name>/` — the deliverable.
-3. `git push -u origin HEAD`.
+3. `git push origin HEAD`.
 
-This lets the user pull the deliverable onto main with: `git checkout <branch> -- experiments/<name>/ && git commit`.
+### F7: Mark draft PR ready
 
-No PR for the report itself. PRs are reserved for cases where the experiment also produced reusable code worth reviewing.
+Find the draft PR for this branch: `gh pr list --head <branch> --state open --json number,isDraft -q '.[] | select(.isDraft)'`. If one exists:
+
+1. Mark it ready: `gh pr ready <number>`.
+2. Rewrite the body: 2-3 sentence summary of findings, link to the report (`experiments/<name>/<name>_report.md`), mention "see § Code changes outside this experiment in the report" if F5 found any.
+
+Skip silently if no draft PR exists (e.g. user invoked with `--no-pr` or the launcher couldn't open one). The deliverable is still on the branch and pushed.
 
 ## Rules
 

--- a/skills/run-experiment/SKILL.md
+++ b/skills/run-experiment/SKILL.md
@@ -3,9 +3,10 @@ name: zombuul:run-experiment
 description: >
   Run an experiment from a spec or description. If given a path to an existing spec, runs it directly.
   If given a natural language description, synthesizes a spec first, then runs it.
-  Argument $ARGUMENTS — `<spec_path_or_description> [--remote]`. Pass `--remote` to execute
+  Argument $ARGUMENTS — `<spec_path_or_description> [--remote] [--no-pr]`. Pass `--remote` to execute
   autonomously on a GPU pod (survives local disconnects); otherwise runs local-first.
-argument-hint: <spec-path-or-description> [--remote]
+  Pass `--no-pr` to skip the draft-PR-on-the-experiment-branch flow.
+argument-hint: <spec-path-or-description> [--remote] [--no-pr]
 user-invocable: true
 ---
 
@@ -18,6 +19,18 @@ Check `$IS_SANDBOX` and `$ARGUMENTS`:
 - **On-pod mode** — if the `IS_SANDBOX=1` env var is set, you are already inside a GPU pod that was launched by a remote-mode invocation. Jump to [On-pod execution](#on-pod-execution). Do not read the rest of this document first.
 - **Remote-launcher mode** — if `$ARGUMENTS` contains the flag `--remote` (strip it before treating the remainder as the spec path/description), go to [Remote-launcher execution](#remote-launcher-execution).
 - **Local mode** — default. `$ARGUMENTS` has no `--remote` flag and `IS_SANDBOX` is unset. Go to [Local execution](#local-execution).
+
+Also strip `--no-pr` from `$ARGUMENTS` if present; pass the flag forward to the on-pod invocation in remote mode.
+
+## Draft PR for the experiment (default — skip with `--no-pr`)
+
+Local and remote-launcher modes open a draft PR on the experiment branch before real work begins. On-pod mode skips this — the launcher already opened the PR.
+
+1. **Capture the base branch.** Run `git rev-parse --abbrev-ref HEAD` BEFORE any branch switching (i.e. before `EnterWorktree` in local mode, before pushing in remote mode). That's the PR base. If you find this is somehow the experiment branch itself (can happen in remote mode if the user pre-created the branch), fall back to `main`.
+2. **Open the PR** after the experiment branch is pushed: `gh pr create --draft --base <base> --head <experiment-branch> --title "<experiment_name>" --body "<spec path; started at <time>; status: in progress; follow along: git fetch && git log origin/<branch> --oneline -- experiments/<name>/>"`. One-line title, short body — finalize rewrites it.
+3. **Announce clearly to the user** which base branch the PR targets and the PR number. Loud enough that they can't miss it.
+
+Skip silently with a one-line warning if `--no-pr` was passed, the repo has no remote, `gh` is unavailable, or push fails for any reason. The experiment itself does not depend on the PR existing.
 
 ## Phase 0: Determine input type (all modes)
 
@@ -67,9 +80,10 @@ When the subagent returns, show the user the spec path and summary. Ask: "Want m
 
 ### Phase 2: Enter worktree and set up
 
-1. **Enter a worktree**: use the `EnterWorktree` tool with name `{experiment_name}` (derived from the spec path, e.g., `experiments/foo/foo_spec.md` → name `foo`).
-2. **Run the symlink commands** returned by the symlink discovery agent. Verify the experiment's input files are accessible.
-3. **Set up infrastructure** if GPU needed:
+1. **Enter a worktree**: use the `EnterWorktree` tool with name `{experiment_name}` (derived from the spec path, e.g., `experiments/foo/foo_spec.md` → name `foo`). You should have already captured the base branch in Phase 0; if not, capture it from the worktree's parent now.
+2. **Push the experiment branch and open the draft PR** as described in [Draft PR for the experiment](#draft-pr-for-the-experiment-default--skip-with---no-pr). Do this before the symlinks/infrastructure steps so the PR is live for the rest of the run.
+3. **Run the symlink commands** returned by the symlink discovery agent. Verify the experiment's input files are accessible.
+4. **Set up infrastructure** if GPU needed:
    - If the infrastructure agent found a running pod, use it.
    - Otherwise: **size the pod based on the spec before invoking launch-runpod.** See [Sizing a pod from the spec](#sizing-a-pod-from-the-spec) below. Then invoke `/zombuul:launch-runpod <pod_name> --disk-gb <N> --volume-gb <N>` (local mode — do NOT pass `--remote`, the pod is just an SSH target). After it completes, sync experiment data via `/zombuul:provision-pod`, passing `data_dirs` explicitly (inferred from the spec) to skip interactive recon.
    - Do NOT ask the user for GPU choice, data dirs, etc. Make reasonable choices. Only ask if truly blocked.
@@ -89,6 +103,7 @@ You are **not** running the experiment — you are setting up a pod that will ru
    - **Data recon subagent** (Agent, subagent_type="general-purpose", model="opus"): "Read the experiment spec at <spec_path>. Find every data path it references (activations .npz, embeddings, topics .json, results directories, configs, probe weights, concept vectors). For each: check whether it exists locally (follow symlinks), whether it's gitignored, and report size (`du -sh`). Return a structured list: `path | exists? | gitignored? | size`. The experiment will run on a GPU pod with only what git provides plus what we explicitly sync — anything gitignored that the spec reads must appear in the sync list."
    - **Push the branch**: commit any relevant unstaged changes (ask before broad commits), then `git push -u origin HEAD`. The pod clones from the remote, so unpushed work is invisible.
 3. **Wait for both**, then **decide `data_dirs`**: gitignored paths the spec reads (not writes) are the default sync set. Do not ask the user; err toward including ambiguous directories — a too-small sync is a silent failure on the pod. Capture the branch name.
+4. **Open the draft PR** as described in [Draft PR for the experiment](#draft-pr-for-the-experiment-default--skip-with---no-pr) before the on-pod agent kicks off. The user will use it to follow progress while their laptop is offline.
 
 ### R2: Pod setup
 


### PR DESCRIPTION
## Summary

Implements the PR-based delivery flow for experiments. Draft PR opens at branch creation; finalize marks it ready with a summary, data inventory, and a flag for outside-of-experiment code changes the researcher made.

### What changes for the researcher

- Run `/zombuul:run-experiment <spec>` on, say, `main`. The skill creates the experiment branch, opens a draft PR against `main`, runs the work. You can watch the running log update on the PR diff as commits land.
- At finalize: the PR auto-marks "ready for review" with a 2–3 sentence summary, a link to the report, and a `## Data used` section (paths + sizes) appended to the report. If you (the agent or you) touched code outside the experiment folder while running, that's flagged as a `## Code changes outside this experiment` section so you can spin off a follow-up PR with just those changes.
- Opt out with `/zombuul:run-experiment <spec> --no-pr`.

### Design (already discussed)

| Decision | Choice |
|---|---|
| PR base | Branch the user was on when invoking (captured pre-`EnterWorktree`). Falls back to `main` if ambiguous. |
| Draft vs ready | Opens draft, marked ready at finalize. |
| Data inventory | Yes, auto-generated. Simple — paths + `du -sh` only. |
| Outside-of-experiment code changes | Excluded from the PR. Flagged in the report so you can open a separate PR. |
| Failure modes (no remote, no `gh`, push fails) | Skip PR silently with a one-line warning. Experiment still runs. |

### Files changed

- `skills/run-experiment/SKILL.md` — adds the "Draft PR" section + references it from local Phase 2 and remote R1. Adds `--no-pr` to argument-hint.
- `skills/finalize-experiment/SKILL.md` — splits old F5 into F5 (data inventory + outside-code-changes-flag), F6 (commit/push), F7 (mark PR ready + rewrite body). Removed the "no PR for the report itself" line.

## Test plan

- [x] `python scripts/validate_plugin.py` passes
- [ ] CI green on this PR
- [ ] Manual end-to-end: invoke `/zombuul:run-experiment <tiny-spec>` from main on a research repo, observe draft PR opens against main, finalize marks it ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)