### PR TITLE
chore: bump dev version to 1.1.24-dev.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.24-dev.3",
+  "version": "1.1.24-dev.4",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",


### PR DESCRIPTION
Auto-bump for plugin cache busting on dev.