### PR TITLE
fix: pod_setup.sh — verify gh auth via status, not login --with-token

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -108,10 +108,15 @@ if [ -z "$GH_TOKEN" ]; then
     echo "       Without it, gh auth login is skipped and any private clone / push will fail mid-experiment."
     exit 1
 fi
-if echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null; then
-    echo "Logged into GitHub (for git auth)."
+# gh CLI uses GH_TOKEN from env automatically when set; calling
+# `gh auth login --with-token` in that case errors out ("To have GitHub CLI
+# store credentials instead, first clear the value from the environment").
+# Verify auth works via env instead — the credential helper below uses gh's
+# auth regardless of whether it came from env or login store.
+if gh auth status >/dev/null 2>&1; then
+    echo "Logged into GitHub via GH_TOKEN env var."
 else
-    echo "FATAL: gh auth login failed — GH_TOKEN may be invalid or expired."
+    echo "FATAL: gh auth status failed despite GH_TOKEN being set — token may be invalid or expired."
     exit 1
 fi
 git config --global credential.helper '!gh auth git-credential'


### PR DESCRIPTION
## Summary
- `gh auth login --with-token` errors out when `GH_TOKEN` is exported in the env. `pod_setup.sh` itself re-exports `GH_TOKEN` from `/proc/1/environ` a few lines up, so the login call always exits non-zero on a fresh pod, hitting the `FATAL` branch and killing setup before clone/install/Claude steps run.
- gh's credential helper works fine with the env-var token, so the login call is redundant. Replace with `gh auth status` as a liveness check.

## Repro (before this fix)

```
scripts/runpod_ctl.py create --name reprobug --gpu "NVIDIA RTX A4000"
scripts/runpod_ctl.py wait-setup <pod_id>
# → ERROR: Setup timed out after 900s
ssh runpod-reprobug 'tail -5 /var/log/pod_setup.log'
# → FATAL: gh auth login failed — GH_TOKEN may be invalid or expired.
```

The token is fine — `gh auth status` confirms gh is authenticated via the env var. The login subcommand just refuses to overwrite an env-driven token.

## Impact
- Without this fix, `/zombuul:run-experiment --remote` is entirely broken (pod_setup exits before installing Claude Code on the pod).
- Local-mode usage requires a manual `wait-setup` / `provision-pod` bypass.

## Test plan
- [ ] On dev: launch a fresh pod (`scripts/runpod_ctl.py create …`) and confirm `wait-setup` reaches "Setup complete" within the normal window.
- [ ] `git push` via the gh credential helper still works on the pod (sanity check that we didn't break credential flow by skipping `login`).
- [ ] `/zombuul:smoke-test` step E completes without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)