### PR TITLE
fix: pod_setup.sh — drop GIT_USER_NAME/EMAIL FATAL, set fixed identity

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -246,18 +246,11 @@ else
 fi
 
 # --- git identity ---
+# Set a generic pod identity so on-pod commits work. Real attribution is
+# established via Co-Authored-By trailers in commit messages anyway.
 
-if [ -f "$REPO_DIR/.env" ]; then
-    GIT_USER_NAME=$(grep '^GIT_USER_NAME=' "$REPO_DIR/.env" | cut -d= -f2-)
-    GIT_USER_EMAIL=$(grep '^GIT_USER_EMAIL=' "$REPO_DIR/.env" | cut -d= -f2-)
-fi
-if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
-    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL missing or empty in $REPO_DIR/.env."
-    echo "       Without these, the pod's git commits will fail with 'Author identity unknown' mid-experiment."
-    exit 1
-fi
-git config --global user.name "$GIT_USER_NAME"
-git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "zombuul-pod"
+git config --global user.email "pod@zombuul.local"
 
 # --- auth (tokens passed via environment) ---
 


### PR DESCRIPTION
## Summary
- The `.env`-based `GIT_USER_NAME`/`GIT_USER_EMAIL` check (added in `2a7533b`) always fires on fresh pods because `pod_setup.sh` runs **before** `/zombuul:provision-pod` syncs `.env`, so `/workspace/repo/.env` doesn't yet have those keys. Setup exits FATAL before any post-clone step completes; `wait-setup` then hangs to its 900s timeout.
- Plumbing the user's git identity through env/.env adds configuration surface for no real benefit — git identity on the pod just needs to be *set* (otherwise `git commit` fails with "Author identity unknown"); attribution is already carried by `Co-Authored-By:` trailers in commit messages.
- Unconditionally set a generic `zombuul-pod <pod@zombuul.local>` identity. 5-line diff.

## Repro (before this fix)

```
scripts/runpod_ctl.py create --name reprobug --gpu "NVIDIA RTX A4000"
scripts/runpod_ctl.py wait-setup <pod_id>
# → ERROR: Setup timed out after 900s
ssh runpod-reprobug 'tail -5 /var/log/pod_setup.log'
# → FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL missing or empty in /workspace/repo/.env.
```

## Test plan
- [ ] Launch fresh pod, `wait-setup` reaches "Setup complete" within normal window.
- [ ] `/zombuul:smoke-test` step C passes (and step E, post-merge of #118).
- [ ] On-pod `git commit -am 'test'` works (no "Author identity unknown").

🤖 Generated with [Claude Code](https://claude.com/claude-code)