### PR TITLE
fix: forward launching user's git identity to the pod

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -50,7 +50,7 @@ retry() {
 # Import container env vars (not inherited when run via nohup over SSH)
 if [ -f /proc/1/environ ]; then
     # shellcheck disable=SC2046
-    export $(tr '\0' '\n' < /proc/1/environ | grep -E '^(HF_TOKEN|GH_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|RUNPOD_POD_ID)=')
+    export $(tr '\0' '\n' < /proc/1/environ | grep -E '^(HF_TOKEN|GH_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|RUNPOD_POD_ID|GIT_USER_NAME|GIT_USER_EMAIL)=')
 fi
 
 # Fallback: check for .env synced by provision-pod.
@@ -59,7 +59,7 @@ for envfile in "$REPO_DIR/.env" /tmp/.env; do
         echo "Found .env at $envfile — sourcing tokens."
         while IFS='=' read -r key value || [ -n "$key" ]; do
             case "$key" in
-                GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY)
+                GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|GIT_USER_NAME|GIT_USER_EMAIL)
                     value="${value%\"}"; value="${value#\"}"
                     value="${value%\'}"; value="${value#\'}"
                     export "$key=$value"
@@ -246,14 +246,14 @@ else
 fi
 
 # --- git identity ---
+# GIT_USER_NAME / GIT_USER_EMAIL are forwarded by runpod_ctl.py, which reads
+# them from the launching user's env / .env / `git config --global user.*`.
+# So on-pod commits are attributed to the real human, not a generic pod user.
 
-if [ -f "$REPO_DIR/.env" ]; then
-    GIT_USER_NAME=$(grep '^GIT_USER_NAME=' "$REPO_DIR/.env" | cut -d= -f2-)
-    GIT_USER_EMAIL=$(grep '^GIT_USER_EMAIL=' "$REPO_DIR/.env" | cut -d= -f2-)
-fi
 if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
-    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL missing or empty in $REPO_DIR/.env."
-    echo "       Without these, the pod's git commits will fail with 'Author identity unknown' mid-experiment."
+    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL not forwarded to the pod."
+    echo "       runpod_ctl.py reads these from env, .env, or 'git config --global user.{name,email}'."
+    echo "       Set one of those on the launching machine, or commits will fail with 'Author identity unknown' mid-experiment."
     exit 1
 fi
 git config --global user.name "$GIT_USER_NAME"

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -102,10 +102,28 @@ def ssh_run(ip: str, port: int, command: str | list[str], **kwargs) -> subproces
 # --- Pod info ---
 
 def get_pod_env() -> dict[str, str]:
-    """Collect tokens for the pod from environment, project .env, and ~/.claude/.env."""
+    """Collect tokens + git identity for the pod from environment, project .env, and ~/.claude/.env.
+
+    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config --global user.{name,email}`
+    so the user's real git identity gets forwarded to the pod without requiring
+    them to duplicate it into .env. pod_setup.sh runs `git config` with these
+    before the experiment can make commits.
+    """
     load_dotenv()  # load project .env into os.environ (no-op for already-set vars)
     load_dotenv(os.path.expanduser("~/.claude/.env"))  # global .env (no-op for already-set vars)
-    return {k: v for k in ("HF_TOKEN", "GH_TOKEN", "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "RUNPOD_API_KEY") if (v := os.environ.get(k))}
+    env = {k: v for k in ("HF_TOKEN", "GH_TOKEN", "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "RUNPOD_API_KEY", "GIT_USER_NAME", "GIT_USER_EMAIL") if (v := os.environ.get(k))}
+    for git_key, config_key in (("GIT_USER_NAME", "user.name"), ("GIT_USER_EMAIL", "user.email")):
+        if git_key not in env:
+            try:
+                result = subprocess.run(
+                    ["git", "config", "--global", config_key],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    env[git_key] = result.stdout.strip()
+            except Exception:
+                pass
+    return env
 
 
 def get_ssh_info(pod_id: str) -> tuple[str | None, int | None]:


### PR DESCRIPTION
## Summary
`pod_setup.sh` asserted `GIT_USER_NAME`/`GIT_USER_EMAIL` were set, but read them only from `/workspace/repo/.env` — a gitignored file that isn't synced to the pod until `/zombuul:provision-pod` runs, **after** `pod_setup.sh`. So setup exited FATAL on every fresh pod and `wait-setup` hung to its 900s timeout. Caught by `/zombuul:smoke-test` after #118 landed.

Forwards the launching user's **real** git identity through the same channel as the tokens, so on-pod commits get attributed to the actual human (contribution graph credit, PR author identity).

## What changed
- `runpod_ctl.py:get_pod_env()` now collects `GIT_USER_NAME`/`GIT_USER_EMAIL` alongside the token set, with a fallback to `git config --global user.{name,email}` if they're not in env or .env. Means **no new .env keys to add** — every dev already has these set via `git config --global` as a side effect of normal git use.
- `pod_setup.sh` `/proc/1/environ` allowlist extended to read both vars, same for the `.env`-fallback parser. Drops the `$REPO_DIR/.env` lookup that ran before `.env` existed on the pod. Updates the FATAL message to point users at the real source.

Resolution order on the launching machine:
1. `GIT_USER_NAME` / `GIT_USER_EMAIL` env var (e.g. CI, explicit override)
2. `.env` in cwd
3. `~/.claude/.env`
4. `git config --global user.{name,email}` ← every dev hits this case

## Test plan
- [ ] Launch a fresh pod; `wait-setup` reaches "Setup complete" within the normal window.
- [ ] `ssh runpod-<name> 'git config --global user.name'` returns the launching user's name (not a hardcoded default).
- [ ] On-pod commits from `/zombuul:run-experiment --remote` show up on GitHub authored by the real human.
- [ ] `/zombuul:smoke-test` step C passes (and step E end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)