### PR TITLE
chore: bump dev version to 1.1.26-dev.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.26-dev.2",
+  "version": "1.1.26-dev.3",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",


### PR DESCRIPTION
Auto-bump for plugin cache busting on dev.