### PR TITLE
Respect per-repo git identity

### DIFF
--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -252,7 +252,7 @@ fi
 
 if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
     echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL not forwarded to the pod."
-    echo "       runpod_ctl.py reads these from env, .env, or 'git config --global user.{name,email}'."
+    echo "       runpod_ctl.py reads these from env, .env, or 'git config user.{name,email}' (repo/global/system)."
     echo "       Set one of those on the launching machine, or commits will fail with 'Author identity unknown' mid-experiment."
     exit 1
 fi

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -104,10 +104,11 @@ def ssh_run(ip: str, port: int, command: str | list[str], **kwargs) -> subproces
 def get_pod_env() -> dict[str, str]:
     """Collect tokens + git identity for the pod from environment, project .env, and ~/.claude/.env.
 
-    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config --global user.{name,email}`
+    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config user.{name,email}`
     so the user's real git identity gets forwarded to the pod without requiring
-    them to duplicate it into .env. pod_setup.sh runs `git config` with these
-    before the experiment can make commits.
+    them to duplicate it into .env. `git config` (no --global) uses git's normal
+    precedence: repo-local → global → system, so per-repo identity is respected
+    when zombuul is invoked from inside a git repo.
     """
     load_dotenv()  # load project .env into os.environ (no-op for already-set vars)
     load_dotenv(os.path.expanduser("~/.claude/.env"))  # global .env (no-op for already-set vars)
@@ -116,7 +117,7 @@ def get_pod_env() -> dict[str, str]:
         if git_key not in env:
             try:
                 result = subprocess.run(
-                    ["git", "config", "--global", config_key],
+                    ["git", "config", config_key],
                     capture_output=True, text=True, timeout=5,
                 )
                 if result.returncode == 0 and result.stdout.strip():


### PR DESCRIPTION
## Summary
- Drop \`--global\` from the \`git config user.{name,email}\` fallback in \`runpod_ctl.py:get_pod_env()\` so git's normal precedence (repo → global → system) applies. Users with per-repo identity (work/personal split) were getting empty values and hitting the FATAL on pod.
- Update the FATAL message in \`pod_setup.sh\` to match.

Follow-up to #121.

## Test plan
- Single-flag removal in an isolated function — repo-only users now get their repo identity; global-only users still get global. No regression path.
- Smoke test doesn't exercise this code path (the smoke experiment doesn't commit from the pod), so no useful additional coverage from re-running.