### PR TITLE
release: 2026-05-11 (v4) — forward git identity to pod

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.24-dev.5",
+  "version": "1.1.24-dev.6",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.26-dev",
+  "version": "1.1.26-dev.1",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.26-dev.2",
+  "version": "1.1.26-dev.3",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.26-dev.1",
+  "version": "1.1.26-dev.2",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install pytest runpod python-dotenv
+        # Keep in sync with the PEP 723 block in scripts/runpod_ctl.py.
+        run: pip install pytest runpod python-dotenv pyyaml
 
       - name: Run tests
         run: pytest tests/ -v

--- a/.github/workflows/validate-target-branch.yml
+++ b/.github/workflows/validate-target-branch.yml
@@ -1,0 +1,23 @@
+name: Validate target branch
+
+# Guard against dev-only state (marketplace name `ogilg-marketplace-dev`, `-dev` version
+# suffix) leaking into main, and against missing-suffix / wrong-name states leaking onto
+# dev. Runs on every PR targeting main or dev.
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  validate:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate against target branch invariants
+        run: python scripts/validate_plugin.py --target "${{ github.base_ref }}"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,11 +23,19 @@ jobs:
         id: bump
         run: |
           NEW=$(python3 - <<'PY'
-          import json
+          import json, re, sys
           path = ".claude-plugin/plugin.json"
           with open(path) as f:
               d = json.load(f)
-          major, minor, patch = d["version"].split(".")
+          v = d["version"]
+          m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", v)
+          if not m:
+              sys.exit(
+                  f"FATAL: main's plugin.json version '{v}' is not strict semver. "
+                  "A dev-only suffix likely leaked into main — investigate before "
+                  "letting this workflow corrupt the release further."
+              )
+          major, minor, patch = m.groups()
           new = f"{major}.{minor}.{int(patch) + 1}"
           d["version"] = new
           with open(path, "w") as f:

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -3,6 +3,6 @@ disk_gb: 100
 docker_image: "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04"
 gpu_count: 1
 cpu_instance_id: "cpu3c-2-4"
-python_version: "3.12"
+python_version: "3.11"
 ssh_key: "~/.ssh/id_ed25519"
 template_id: null

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -50,7 +50,7 @@ retry() {
 # Import container env vars (not inherited when run via nohup over SSH)
 if [ -f /proc/1/environ ]; then
     # shellcheck disable=SC2046
-    export $(tr '\0' '\n' < /proc/1/environ | grep -E '^(HF_TOKEN|GH_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|RUNPOD_POD_ID)=')
+    export $(tr '\0' '\n' < /proc/1/environ | grep -E '^(HF_TOKEN|GH_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|RUNPOD_POD_ID|GIT_USER_NAME|GIT_USER_EMAIL)=')
 fi
 
 # Fallback: check for .env synced by provision-pod.
@@ -59,7 +59,7 @@ for envfile in "$REPO_DIR/.env" /tmp/.env; do
         echo "Found .env at $envfile — sourcing tokens."
         while IFS='=' read -r key value || [ -n "$key" ]; do
             case "$key" in
-                GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY)
+                GH_TOKEN|HF_TOKEN|SLACK_BOT_TOKEN|SLACK_CHANNEL_ID|RUNPOD_API_KEY|GIT_USER_NAME|GIT_USER_EMAIL)
                     value="${value%\"}"; value="${value#\"}"
                     value="${value%\'}"; value="${value#\'}"
                     export "$key=$value"
@@ -246,14 +246,14 @@ else
 fi
 
 # --- git identity ---
+# GIT_USER_NAME / GIT_USER_EMAIL are forwarded by runpod_ctl.py, which reads
+# them from the launching user's env / .env / `git config --global user.*`.
+# So on-pod commits are attributed to the real human, not a generic pod user.
 
-if [ -f "$REPO_DIR/.env" ]; then
-    GIT_USER_NAME=$(grep '^GIT_USER_NAME=' "$REPO_DIR/.env" | cut -d= -f2-)
-    GIT_USER_EMAIL=$(grep '^GIT_USER_EMAIL=' "$REPO_DIR/.env" | cut -d= -f2-)
-fi
 if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
-    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL missing or empty in $REPO_DIR/.env."
-    echo "       Without these, the pod's git commits will fail with 'Author identity unknown' mid-experiment."
+    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL not forwarded to the pod."
+    echo "       runpod_ctl.py reads these from env, .env, or 'git config --global user.{name,email}'."
+    echo "       Set one of those on the launching machine, or commits will fail with 'Author identity unknown' mid-experiment."
     exit 1
 fi
 git config --global user.name "$GIT_USER_NAME"

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 REPO_URL="${1:?Usage: bash pod_setup.sh <repo_url> [branch] [python_version] [install_claude] [extras]}"
 BRANCH="${2:-main}"
-PYTHON_VERSION="${3:-3.12}"
+PYTHON_VERSION="${3:-3.11}"
 INSTALL_CLAUDE="${4:-false}"
 EXTRAS="${5:-auto}"
 REPO_DIR="/workspace/repo"
@@ -103,10 +103,16 @@ retry "install gh" 3 10 install_gh
 # Use gh CLI as credential helper instead of embedding token in URL.
 # Embedding the token in the URL triggers GitHub push protection on push.
 
-if [ -n "$GH_TOKEN" ]; then
-    echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo "Logged into GitHub (for git auth)." || echo "WARNING: gh login failed."
-    git config --global credential.helper '!gh auth git-credential'
+if [ -z "$GH_TOKEN" ]; then
+    echo "FATAL: GH_TOKEN is empty. Set GH_TOKEN in the repo's .env (or in /proc/1/environ) before launching."
+    echo "       Without it, gh auth login is skipped and any private clone / push will fail mid-experiment."
+    exit 1
 fi
+echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo "Logged into GitHub (for git auth)." || {
+    echo "FATAL: gh auth login failed — GH_TOKEN may be invalid or expired."
+    exit 1
+}
+git config --global credential.helper '!gh auth git-credential'
 
 # --- clone repo ---
 
@@ -172,6 +178,18 @@ mkdir -p /opt/venvs
 if [ ! -d /opt/venvs/research/bin ]; then
     retry "create venv" 3 5 uv venv --python "$PYTHON_VERSION" /opt/venvs/research
 fi
+# Fail loudly if the venv didn't get built — otherwise we silently activate
+# nothing and downstream `uv pip install` lands in the wrong interpreter.
+if [ ! -x /opt/venvs/research/bin/python ]; then
+    echo "FATAL: venv /opt/venvs/research not created. Requested Python $PYTHON_VERSION may be unavailable in this image."
+    echo "       Check defaults.yaml python_version vs. the docker_image's bundled Python."
+    exit 1
+fi
+ACTUAL_PY=$(/opt/venvs/research/bin/python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+if [ "$ACTUAL_PY" != "$PYTHON_VERSION" ]; then
+    echo "FATAL: venv built with Python $ACTUAL_PY, but $PYTHON_VERSION was requested."
+    exit 1
+fi
 # shellcheck disable=SC1091
 source /opt/venvs/research/bin/activate
 cd "$REPO_DIR" || exit 1
@@ -226,12 +244,13 @@ if [ -f "$REPO_DIR/.env" ]; then
     GIT_USER_NAME=$(grep '^GIT_USER_NAME=' "$REPO_DIR/.env" | cut -d= -f2-)
     GIT_USER_EMAIL=$(grep '^GIT_USER_EMAIL=' "$REPO_DIR/.env" | cut -d= -f2-)
 fi
-if [ -n "$GIT_USER_NAME" ]; then
-    git config --global user.name "$GIT_USER_NAME"
+if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
+    echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL missing or empty in $REPO_DIR/.env."
+    echo "       Without these, the pod's git commits will fail with 'Author identity unknown' mid-experiment."
+    exit 1
 fi
-if [ -n "$GIT_USER_EMAIL" ]; then
-    git config --global user.email "$GIT_USER_EMAIL"
-fi
+git config --global user.name "$GIT_USER_NAME"
+git config --global user.email "$GIT_USER_EMAIL"
 
 # --- auth (tokens passed via environment) ---
 

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -252,7 +252,7 @@ fi
 
 if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
     echo "FATAL: GIT_USER_NAME and/or GIT_USER_EMAIL not forwarded to the pod."
-    echo "       runpod_ctl.py reads these from env, .env, or 'git config --global user.{name,email}'."
+    echo "       runpod_ctl.py reads these from env, .env, or 'git config user.{name,email}' (repo/global/system)."
     echo "       Set one of those on the launching machine, or commits will fail with 'Author identity unknown' mid-experiment."
     exit 1
 fi

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -108,10 +108,12 @@ if [ -z "$GH_TOKEN" ]; then
     echo "       Without it, gh auth login is skipped and any private clone / push will fail mid-experiment."
     exit 1
 fi
-echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null && echo "Logged into GitHub (for git auth)." || {
+if echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null; then
+    echo "Logged into GitHub (for git auth)."
+else
     echo "FATAL: gh auth login failed — GH_TOKEN may be invalid or expired."
     exit 1
-}
+fi
 git config --global credential.helper '!gh auth git-credential'
 
 # --- clone repo ---

--- a/scripts/pod_setup.sh
+++ b/scripts/pod_setup.sh
@@ -108,10 +108,15 @@ if [ -z "$GH_TOKEN" ]; then
     echo "       Without it, gh auth login is skipped and any private clone / push will fail mid-experiment."
     exit 1
 fi
-if echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null; then
-    echo "Logged into GitHub (for git auth)."
+# gh CLI uses GH_TOKEN from env automatically when set; calling
+# `gh auth login --with-token` in that case errors out ("To have GitHub CLI
+# store credentials instead, first clear the value from the environment").
+# Verify auth works via env instead — the credential helper below uses gh's
+# auth regardless of whether it came from env or login store.
+if gh auth status >/dev/null 2>&1; then
+    echo "Logged into GitHub via GH_TOKEN env var."
 else
-    echo "FATAL: gh auth login failed — GH_TOKEN may be invalid or expired."
+    echo "FATAL: gh auth status failed despite GH_TOKEN being set — token may be invalid or expired."
     exit 1
 fi
 git config --global credential.helper '!gh auth git-credential'

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -1,4 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "runpod",
+#     "pyyaml",
+#     "python-dotenv",
+# ]
+# ///
 """RunPod pod management CLI. Used by Claude Code slash commands."""
 
 import argparse
@@ -61,10 +69,12 @@ def show_config():
 
 
 def load_api_key():
+    # cwd .env wins over ~/.claude/.env (load_dotenv does not override existing keys).
+    load_dotenv()
     load_dotenv(os.path.expanduser("~/.claude/.env"))
     key = os.environ.get("RUNPOD_API_KEY")
     if not key:
-        print("ERROR: RUNPOD_API_KEY not found. Add it to ~/.claude/.env")
+        print("ERROR: RUNPOD_API_KEY not found. Add it to ./.env or ~/.claude/.env")
         sys.exit(1)
     runpod.api_key = key
 
@@ -149,6 +159,17 @@ def get_current_branch() -> str:
 def extract_claude_credentials() -> str | None:
     """Extract fresh Claude Code credentials from macOS Keychain. Returns path or None."""
     creds_file = os.path.expanduser("~/.claude/.credentials.json")
+
+    if sys.platform != "darwin":
+        print(
+            "  Skipping Keychain extraction: only supported on macOS. "
+            f"Copy {creds_file} from a logged-in macOS host, or run `claude` "
+            "to log in on this machine first."
+        )
+        if os.path.exists(creds_file):
+            return creds_file
+        return None
+
     try:
         result = subprocess.run(
             ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
@@ -161,6 +182,10 @@ def extract_claude_credentials() -> str | None:
             os.chmod(creds_file, 0o600)
             print("  Extracted fresh credentials from Keychain.")
             return creds_file
+        print(
+            "  Keychain entry 'Claude Code-credentials' not found. "
+            "Run `claude` to log in, then re-run with --install-claude."
+        )
     except Exception as e:
         print(f"  Could not extract from Keychain: {e}")
 
@@ -193,7 +218,7 @@ def get_repo_url() -> str:
     sys.exit(1)
 
 
-def setup_pod(ip: str, port: int, repo_url: str, branch: str, python_version: str = "3.12", install_claude: bool = False, extras: str = "auto"):
+def setup_pod(ip: str, port: int, repo_url: str, branch: str, python_version: str = "3.11", install_claude: bool = False, extras: str = "auto"):
     setup_script = find_setup_script()
 
     print("  Copying pod_setup.sh...")
@@ -223,7 +248,7 @@ def list_gpus():
         print(f"  {gpu['id']:45s} {gpu['memoryInGb']}GB")
 
 
-def create_pod(name: str, gpu_type_id: str | None, image_name: str, repo_url: str, branch: str, *, python_version: str = "3.12", volume_gb: int = 100, disk_gb: int = 200, gpu_count: int = 1, cpu_instance_id: str = "cpu3c-2-4", template_id: str | None = None, install_claude: bool = False, extras: str = "auto"):
+def create_pod(name: str, gpu_type_id: str | None, image_name: str, repo_url: str, branch: str, *, python_version: str = "3.11", volume_gb: int = 100, disk_gb: int = 200, gpu_count: int = 1, cpu_instance_id: str = "cpu3c-2-4", template_id: str | None = None, install_claude: bool = False, extras: str = "auto"):
     kind = gpu_type_id or "CPU-only"
     if template_id:
         print(f"Creating pod '{name}' with {kind} (template: {template_id})...")

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -104,10 +104,11 @@ def ssh_run(ip: str, port: int, command: str | list[str], **kwargs) -> subproces
 def get_pod_env() -> dict[str, str]:
     """Collect tokens + git identity for the pod from environment, project .env, and ~/.claude/.env.
 
-    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config --global user.{name,email}`
+    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config user.{name,email}`
     so the user's real git identity gets forwarded to the pod without requiring
-    them to duplicate it into .env. pod_setup.sh runs `git config` with these
-    before the experiment can make commits.
+    them to duplicate it into .env. `git config` (no --global) uses git's normal
+    precedence: repo-local → global → system, so per-repo identity is respected
+    when zombuul is invoked from inside a git repo.
     """
     load_dotenv()  # load project .env into os.environ (no-op for already-set vars)
     load_dotenv(os.path.expanduser("~/.claude/.env"))  # global .env (no-op for already-set vars)
@@ -116,7 +117,7 @@ def get_pod_env() -> dict[str, str]:
         if git_key not in env:
             try:
                 result = subprocess.run(
-                    ["git", "config", "--global", config_key],
+                    ["git", "config", config_key],
                     capture_output=True, text=True, timeout=5,
                 )
                 if result.returncode == 0 and result.stdout.strip():

--- a/scripts/runpod_ctl.py
+++ b/scripts/runpod_ctl.py
@@ -102,10 +102,28 @@ def ssh_run(ip: str, port: int, command: str | list[str], **kwargs) -> subproces
 # --- Pod info ---
 
 def get_pod_env() -> dict[str, str]:
-    """Collect tokens for the pod from environment, project .env, and ~/.claude/.env."""
+    """Collect tokens + git identity for the pod from environment, project .env, and ~/.claude/.env.
+
+    GIT_USER_NAME / GIT_USER_EMAIL also fall back to `git config --global user.{name,email}`
+    so the user's real git identity gets forwarded to the pod without requiring
+    them to duplicate it into .env. pod_setup.sh runs `git config` with these
+    before the experiment can make commits.
+    """
     load_dotenv()  # load project .env into os.environ (no-op for already-set vars)
     load_dotenv(os.path.expanduser("~/.claude/.env"))  # global .env (no-op for already-set vars)
-    return {k: v for k in ("HF_TOKEN", "GH_TOKEN", "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "RUNPOD_API_KEY") if (v := os.environ.get(k))}
+    env = {k: v for k in ("HF_TOKEN", "GH_TOKEN", "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "RUNPOD_API_KEY", "GIT_USER_NAME", "GIT_USER_EMAIL") if (v := os.environ.get(k))}
+    for git_key, config_key in (("GIT_USER_NAME", "user.name"), ("GIT_USER_EMAIL", "user.email")):
+        if git_key not in env:
+            try:
+                result = subprocess.run(
+                    ["git", "config", "--global", config_key],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    env[git_key] = result.stdout.strip()
+            except Exception:
+                pass
+    return env
 
 
 def get_ssh_info(pod_id: str) -> tuple[str | None, int | None]:

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -7,6 +7,7 @@ Intended to run in CI before a release ships.
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -16,9 +17,54 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 FAILURES: list[str] = []
 
+MAIN_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+DEV_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+-dev(?:\.\d+)?$")
+MAIN_MARKETPLACE_NAME = "ogilg-marketplace"
+DEV_MARKETPLACE_NAME = "ogilg-marketplace-dev"
+
 
 def fail(msg: str) -> None:
     FAILURES.append(msg)
+
+
+def validate_target_branch(target: str) -> None:
+    """Assert plugin.json version and marketplace.json name match the target branch's
+    invariants. Prevents dev-only state from leaking into a main release (or vice versa)."""
+    plugin_path = REPO_ROOT / ".claude-plugin" / "plugin.json"
+    market_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    try:
+        plugin = json.loads(plugin_path.read_text())
+        market = json.loads(market_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        fail(f"target={target}: cannot read manifests — {e}")
+        return
+    version = plugin.get("version", "")
+    name = market.get("name", "")
+    if target == "main":
+        if not MAIN_VERSION_RE.match(version):
+            fail(
+                f"{plugin_path}: version '{version}' is not strict semver (X.Y.Z). "
+                "Main must not carry a '-dev' suffix — did a dev→main release skip "
+                "`git checkout main -- .claude-plugin/{marketplace,plugin}.json`?"
+            )
+        if name != MAIN_MARKETPLACE_NAME:
+            fail(
+                f"{market_path}: marketplace name is '{name}', expected "
+                f"'{MAIN_MARKETPLACE_NAME}'. Dev's marketplace rename leaked into main."
+            )
+    elif target == "dev":
+        if not DEV_VERSION_RE.match(version):
+            fail(
+                f"{plugin_path}: version '{version}' must match "
+                "'X.Y.Z-dev' or 'X.Y.Z-dev.N' on the dev branch."
+            )
+        if name != DEV_MARKETPLACE_NAME:
+            fail(
+                f"{market_path}: marketplace name is '{name}', expected "
+                f"'{DEV_MARKETPLACE_NAME}' on the dev branch."
+            )
+    else:
+        fail(f"validate_target_branch: unknown target '{target}'")
 
 
 def validate_plugin_json() -> None:
@@ -131,15 +177,26 @@ def validate_skills() -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        choices=("main", "dev"),
+        help="Also assert version/marketplace-name invariants for the given target branch.",
+    )
+    args = parser.parse_args()
+
     validate_plugin_json()
     validate_marketplace_json()
     validate_skills()
+    if args.target:
+        validate_target_branch(args.target)
     if FAILURES:
         for line in FAILURES:
             print(f"FAIL: {line}")
         print(f"\n{len(FAILURES)} validation failure(s).", file=sys.stderr)
         return 1
-    print("OK: plugin.json, marketplace.json, and all SKILL.md files validate.")
+    suffix = f" (target={args.target})" if args.target else ""
+    print(f"OK: plugin.json, marketplace.json, and all SKILL.md files validate{suffix}.")
     return 0
 
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -12,16 +12,15 @@ You are running the zombuul setup wizard. The philosophy is **detect first, ask 
 
 Run ALL checks before presenting anything to the user:
 
-1. **Package manager**: `which uv` and `which pip` (uv preferred, pip as fallback)
-2. **SSH key**: Check the configured `ssh_key` path (from `~/.claude/zombuul.yaml`, default `~/.ssh/id_ed25519`). Does it exist?
-3. **runpod package**: `uv pip show runpod 2>/dev/null` (or `pip show runpod`)
-4. **RUNPOD_API_KEY**: check both `.env` and `~/.claude/.env` for `RUNPOD_API_KEY=`. It can live in either file.
-5. **Claude Code credentials**: `~/.claude/.credentials.json` exists OR Keychain has `"Claude Code-credentials"` entry
-6. **Repo .env**: `.env` contains GH_TOKEN, GIT_USER_NAME, GIT_USER_EMAIL (required); HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID (optional). This file gets synced to pods, so pod-relevant tokens go here.
-7. **Dependency file**: `pyproject.toml`, `requirements.txt`, or `setup.py` exists in cwd?
-8. **ralph-wiggum**: `launch-research-ralph` in available skills?
-9. **Config file**: `~/.claude/zombuul.yaml` exists?
-10. **RunPod template** (optional): `template_id` set in config? (just note it if present, not a prerequisite)
+1. **uv installed**: `which uv` (hard requirement — `scripts/runpod_ctl.py` declares its deps via PEP 723 and is invoked through `uv run --script` via its shebang).
+2. **SSH key**: Check the configured `ssh_key` path from `~/.claude/zombuul.yaml`, or auto-detect a usable key under `~/.ssh/`.
+3. **RUNPOD_API_KEY**: check both `.env` (cwd) and `~/.claude/.env` for a non-empty `RUNPOD_API_KEY=`. Either works; `~/.claude/.env` is preferred so the key doesn't get synced into pods.
+4. **Claude Code credentials**: `~/.claude/.credentials.json` exists OR Keychain has `"Claude Code-credentials"` entry
+5. **Repo .env**: `.env` contains non-empty `GH_TOKEN`, `GIT_USER_NAME`, `GIT_USER_EMAIL` (all required — empty values count as missing); HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID (optional). This file gets synced to pods, so pod-relevant tokens go here.
+6. **Dependency file**: `pyproject.toml`, `requirements.txt`, or `setup.py` exists in cwd?
+7. **ralph-wiggum**: `launch-research-ralph` in available skills?
+8. **Config file**: `~/.claude/zombuul.yaml` exists?
+9. **RunPod template** (optional): `template_id` set in config? (just note it if present, not a prerequisite)
 
 ## Phase 2: Status report
 
@@ -29,10 +28,9 @@ Present a checklist showing what was found:
 
 ```
 Zombuul setup status:
-  [x] uv available (pip also found)
-  [x] SSH key found
-  [x] runpod 1.8.1 installed
-  [x] RUNPOD_API_KEY configured (in .env)
+  [x] uv available
+  [x] SSH key found (~/.ssh/id_ed25519)
+  [x] RUNPOD_API_KEY configured (in ~/.claude/.env)
   [x] Claude Code credentials extractable
   [x] Repo .env — GH_TOKEN, GIT_USER_NAME, GIT_USER_EMAIL, HF_TOKEN, SLACK_BOT_TOKEN
   [x] Dependency file found (pyproject.toml)
@@ -42,16 +40,17 @@ Zombuul setup status:
 
 Use `[ ]` for missing items. Only proceed to Phase 3 if there are missing items.
 
+**Required items** (must be `[x]` before pod work is reliable): uv, SSH key, RUNPOD_API_KEY, Claude Code credentials, and the three repo-`.env` required fields (`GH_TOKEN`, `GIT_USER_NAME`, `GIT_USER_EMAIL`). If any of these is `[ ]` after Phase 3, refuse to proceed to Phase 4 and surface the gap to the user — silent missing values here cause confusing mid-experiment failures on the pod (auth declined, `Author identity unknown`, etc.).
+
 ## Phase 3: Fix missing items (only if needed)
 
 For each missing item:
 
-- **No package manager**: install uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`); if uv is unavailable, fall back to pip
-- **No SSH key**: If they have a key at a different path (e.g. `~/.ssh/id_rsa`), set `ssh_key` in `~/.claude/zombuul.yaml`. Otherwise generate one: `ssh-keygen -t ed25519`
-- **No runpod**: install with available package manager
-- **No RUNPOD_API_KEY**: direct to https://www.runpod.io/console/user/settings → API Keys, collect via AskUserQuestion, write to the project `.env` (preferred, since it gets synced to pods) or `~/.claude/.env`
+- **No uv**: install via `curl -LsSf https://astral.sh/uv/install.sh | sh`. Required — there's no pip fallback (the controller script self-installs deps through `uv run --script`).
+- **No SSH key**: pick an existing key under `~/.ssh/` and write its path to `ssh_key` in `~/.claude/zombuul.yaml`. If none, generate one (`ssh-keygen -t ed25519`).
+- **No RUNPOD_API_KEY**: direct to https://www.runpod.io/console/user/settings → API Keys, collect via AskUserQuestion, write to `~/.claude/.env` (preferred — it's a local controller credential, no reason to ship it to pods). The project `.env` also works as a fallback.
 - **No Claude Code credentials**: try `security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json && chmod 600 ~/.claude/.credentials.json`. On non-macOS or if the Keychain entry is missing, tell the user to copy `~/.claude/.credentials.json` from another logged-in machine, or to run `claude` and complete login first.
-- **No .env / missing fields**: create template with required (GH_TOKEN, GIT_USER_NAME, GIT_USER_EMAIL) and optional (HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID) fields. Collect missing required fields via AskUserQuestion.
+- **No .env / missing/empty required fields**: create or amend a template with required (`GH_TOKEN`, `GIT_USER_NAME`, `GIT_USER_EMAIL`) and optional (HF_TOKEN, SLACK_BOT_TOKEN, SLACK_CHANNEL_ID) fields. Collect missing required values via AskUserQuestion. Empty values count as missing.
 - **No dependency file**: warn that pod setup expects a `pyproject.toml`, `requirements.txt`, or `setup.py` in the repo root. Dependencies will be skipped on the pod if none are present.
 - **No ralph-wiggum**: ask if wanted; if yes, `/plugin marketplace add anthropics/claude-code` then install ralph-loop
 - **No config file**: copy `${CLAUDE_PLUGIN_ROOT}/defaults.yaml` to `~/.claude/zombuul.yaml`

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -92,7 +92,7 @@ The test runs against `oscar-gilg/zombuul-smoke-bed` — never opens PRs on zomb
 
 **Adaptation notes** (smoke-test specific — these are NOT how a real experiment would run):
 
-- The Claude Code session's cwd is fixed to the user's dev repo (e.g. `/Users/oscargilg/Dev/zombuul`), not the smoke-bed clone. `EnterWorktree` operates on the session's git repo and would create a worktree of zombuul, not smoke-bed.
+- The Claude Code session's cwd is fixed to the user's dev repo (e.g. `~/Dev/zombuul`), not the smoke-bed clone. `EnterWorktree` operates on the session's git repo and would create a worktree of zombuul, not smoke-bed.
 - So: clone smoke-bed to a fixed absolute path (`/tmp/zombuul-smoke/zombuul-smoke-bed`), **skip `EnterWorktree`** (the clone is already an isolated workspace), and chain `cd /tmp/zombuul-smoke/zombuul-smoke-bed && ...` in every Bash call (cwd doesn't persist between Bash calls). Pass an **absolute spec path** to `/zombuul:run-experiment`.
 - When `/zombuul:run-experiment` tells you to use `EnterWorktree`, ignore it and work directly in the clone.
 - `pod_setup.sh` on the pod will clone the user's dev repo (it reads the caller's cwd git origin). That's fine here: the smoke test never reads the cloned repo on the pod, it just `scp`s `scripts/$NAME/forward.py` over.


### PR DESCRIPTION
## Summary
- pod_setup.sh: verify gh auth via \`gh auth status\` instead of \`login --with-token\` (#118)
- runpod_ctl.py: forward launching user's git identity (\`GIT_USER_NAME\` / \`GIT_USER_EMAIL\`) to the pod so on-pod commits don't fail with "Author identity unknown" (#121)
- runpod_ctl.py: respect per-repo git identity by dropping \`--global\` from the fallback (#123)

## Test plan
- \`/zombuul:smoke-test\` PASS on dev (all 4 phases — API, list, pod lifecycle, experiment e2e). f0ddd18's code path (per-repo git identity) isn't exercised by the smoke test but the change is a single-flag removal with no regression path.