### PR TITLE
sync: main → dev (v1.1.27)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",


### PR DESCRIPTION
Bring main's v1.1.27 onto dev.

## Dev-only fields preserved
- \`.claude-plugin/marketplace.json\`: name = \`ogilg-marketplace-dev\`
- \`.claude-plugin/plugin.json\`: version = \`1.1.27-dev\` (auto-bump-dev will append .N on next push)