### PR TITLE
Fix test_get_pod_env_filters_correctly leaking host git identity

### DIFF
--- a/tests/test_runpod_ctl.py
+++ b/tests/test_runpod_ctl.py
@@ -19,7 +19,7 @@ def test_ssh_cmd_format():
 
 
 def test_get_pod_env_filters_correctly():
-    with patch.dict("os.environ", {"HF_TOKEN": "hf_abc", "GH_TOKEN": "gh_xyz", "SLACK_BOT_TOKEN": "xoxb-123", "SLACK_CHANNEL_ID": "C123", "RUNPOD_API_KEY": "rp_key", "UNRELATED": "x"}):
+    with patch.dict("os.environ", {"HF_TOKEN": "hf_abc", "GH_TOKEN": "gh_xyz", "SLACK_BOT_TOKEN": "xoxb-123", "SLACK_CHANNEL_ID": "C123", "RUNPOD_API_KEY": "rp_key", "UNRELATED": "x"}, clear=True):
         with patch("runpod_ctl.load_dotenv") as mock_load:
             env = runpod_ctl.get_pod_env()
             assert env == {"HF_TOKEN": "hf_abc", "GH_TOKEN": "gh_xyz", "SLACK_BOT_TOKEN": "xoxb-123", "SLACK_CHANNEL_ID": "C123", "RUNPOD_API_KEY": "rp_key"}


### PR DESCRIPTION
## Summary
- `patch.dict("os.environ", ...)` without `clear=True` left `GIT_USER_NAME` / `GIT_USER_EMAIL` fallbacks reachable via `git config`, so the test failed on any machine with a global git identity set.
- CI passed only because the runner has no global config. The sibling `test_get_pod_env_missing_tokens` already uses `clear=True` — match it.

## Test plan
- [x] `pytest tests/ -q` passes locally (17 passed) with global git identity set

🤖 Generated with [Claude Code](https://claude.com/claude-code)