### PR TITLE
chore: bump dev version to 1.1.27-dev.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zombuul",
-  "version": "1.1.27-dev.1",
+  "version": "1.1.27-dev.2",
   "description": "Run experiments on GPU pods from local Claude Code",
   "author": {
     "name": "Oscar Gilg",


### PR DESCRIPTION
Auto-bump for plugin cache busting on dev.